### PR TITLE
feat: expose per-borrower collateral and debt positions

### DIFF
--- a/src/resources/erc20.abi.js
+++ b/src/resources/erc20.abi.js
@@ -1,0 +1,9 @@
+export default [
+  {
+    inputs: [{ internalType: 'address', name: 'account', type: 'address' }],
+    name: 'balanceOf',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function'
+  }
+];

--- a/src/utils/borrowers.js
+++ b/src/utils/borrowers.js
@@ -3,17 +3,21 @@ import {grafanaDatasource, grafanaUrl, liquidationAlert} from "../config.js";
 import Grafana from "./grafana.js";
 import {normalizeAddress, provider, toAccount} from "./evm.js";
 import poolAbi from "../resources/aave-pool.abi.js";
+import erc20Abi from "../resources/erc20.abi.js";
+import ERC20Mapping from "./erc20mapping.js";
 import ethers from "ethers";
 import PQueue from "p-queue";
 import {endpoints} from "../endpoints.js";
 import memoize from "memoizee";
 import {broadcastOnce} from "../discord.js";
-import {formatAccount, formatUsdNumber, loadCurrency} from "../currencies.js";
+import {decimals, formatAccount, formatUsdNumber, loadCurrency, symbol} from "../currencies.js";
 import {getAlerts} from "./alerts.js";
 
 export default class Borrowers {
   constructor() {
     this.health = {};
+    this.positions = {};
+    this.reservesCache = new Map();
     this.lastGlobalUpdate = -1;
     this.queue = new PQueue({concurrency: 20, timeout: 10000});
 
@@ -80,20 +84,41 @@ export default class Borrowers {
         lastUpdate: this.metrics.last_update_block.hashMap[''].value || -1,
         borrowers: this.byHealth().filter(([, data]) => data.healthFactor < 2)
       }),
+    }, '/positions': {
+      GET: (_, res) => res.json({
+        lastUpdate: this.metrics.last_update_block.hashMap[''].value || -1,
+        positions: this.allPositions(),
+      }),
+    }, '/positions/:address': {
+      GET: ({params: {address}}, res) => res.json(this.positionsFor(address)),
     }, '/:address': {
       GET: ({params: {address}}, res) => res.json(this.byHealth().filter(([user]) => address === user).map(([_, data]) => data)),
     }
+  }
+
+  allPositions() {
+    return Object.values(this.positions).flatMap(m => Array.from(m.values()));
+  }
+
+  positionsFor(address) {
+    const normalized = address.toLowerCase();
+    return this.allPositions().filter(p => p.address === normalized);
   }
 
   handler(inner) {
     return async payload => {
       await inner(payload);
       const {log: {args: {user}}, event: {data: {log: {address}}}, blockNumber} = payload;
+      const contract = address.toHex();
+      const account = user?.toLowerCase();
       try {
-        await this.update(address.toHex(), user?.toLowerCase());
+        await Promise.all([
+          this.update(contract, account),
+          this.updatePositions(contract, account),
+        ]);
         this.metrics.last_update_block.set(blockNumber);
       } catch (e) {
-        console.error('failed to update borrower health', address, e);
+        console.error('failed to update borrower health/positions', address, e);
       }
     }
   }
@@ -111,7 +136,10 @@ export default class Borrowers {
       const [contracts, addresses] = await grafana.query("select distinct contract, topic2 from frontier_evm_log where topic0 = '0xb3d084820fb1a9decffb176436bd02558d15fac9b0ddfed8c465bc7359d7dce0'");
       const start = performance.now();
       const blockNumber = await provider.getBlockNumber();
-      await Promise.all(addresses.map((address, i) => this.update(contracts[i], normalizeAddress(address))));
+      await Promise.all(addresses.flatMap((address, i) => [
+        this.update(contracts[i], normalizeAddress(address)),
+        this.updatePositions(contracts[i], normalizeAddress(address)),
+      ]));
       this.lastGlobalUpdate = blockNumber;
       this.metrics.last_global_update_block.set(blockNumber);
       this.metrics.last_update_block.set(blockNumber);
@@ -161,6 +189,95 @@ export default class Borrowers {
 
     this.metrics.queue_length.set(this.queue.size);
     this.metrics.queue_pending.set(this.queue.pending);
+  }
+
+  async loadReserves(contract) {
+    if (this.reservesCache.has(contract)) return this.reservesCache.get(contract);
+    const poolContract = new ethers.Contract(contract, poolAbi, provider);
+    const reserveAddresses = await poolContract.getReservesList();
+    const reserves = await Promise.all(reserveAddresses.map(async reserve => {
+      const data = await poolContract.getReserveData(reserve);
+      const currencyId = ERC20Mapping.decodeEvmAddress(reserve);
+      if (currencyId != null) {
+        try { await loadCurrency(currencyId); } catch {}
+      }
+      return {
+        reserve: reserve.toLowerCase(),
+        id: Number(data.id),
+        aToken: data.aTokenAddress,
+        variableDebtToken: data.variableDebtTokenAddress,
+        stableDebtToken: data.stableDebtTokenAddress,
+        currencyId,
+        symbol: currencyId != null ? symbol(currencyId) : null,
+        decimals: currencyId != null ? decimals(currencyId) : 18,
+      };
+    }));
+    this.reservesCache.set(contract, reserves);
+    return reserves;
+  }
+
+  async updatePositions(contract, address) {
+    if (!ethers.utils.isAddress(address)) return;
+    if (!this.positions[contract]) this.positions[contract] = new Map();
+
+    await this.queue.add(async () => {
+      try {
+        const reserves = await this.loadReserves(contract);
+        const poolContract = new ethers.Contract(contract, poolAbi, provider);
+        const config = await poolContract.getUserConfiguration(address);
+        const bitmap = BigInt(config.data.toString());
+
+        const collateral = [];
+        const debt = [];
+
+        await Promise.all(reserves.map(async r => {
+          const idx = BigInt(r.id);
+          const isBorrowing = ((bitmap >> (2n * idx)) & 1n) === 1n;
+          const isCollateral = ((bitmap >> (2n * idx + 1n)) & 1n) === 1n;
+          if (!isBorrowing && !isCollateral) return;
+
+          const tasks = [];
+          if (isCollateral) {
+            const a = new ethers.Contract(r.aToken, erc20Abi, provider);
+            tasks.push(a.balanceOf(address).then(raw => collateral.push({
+              reserve: r.reserve,
+              currencyId: r.currencyId,
+              symbol: r.symbol,
+              decimals: r.decimals,
+              raw: raw.toString(),
+              amount: Number(ethers.utils.formatUnits(raw, r.decimals)),
+            })));
+          }
+          if (isBorrowing) {
+            const v = new ethers.Contract(r.variableDebtToken, erc20Abi, provider);
+            const s = new ethers.Contract(r.stableDebtToken, erc20Abi, provider);
+            tasks.push(Promise.all([v.balanceOf(address), s.balanceOf(address)]).then(([rawV, rawS]) => debt.push({
+              reserve: r.reserve,
+              currencyId: r.currencyId,
+              symbol: r.symbol,
+              decimals: r.decimals,
+              variableRaw: rawV.toString(),
+              variableAmount: Number(ethers.utils.formatUnits(rawV, r.decimals)),
+              stableRaw: rawS.toString(),
+              stableAmount: Number(ethers.utils.formatUnits(rawS, r.decimals)),
+            })));
+          }
+          await Promise.all(tasks);
+        }));
+
+        const account = await toAccount(address);
+        this.positions[contract].set(address, {
+          address,
+          account: account.toString(),
+          pool: contract,
+          collateral,
+          debt,
+          updated: Date.now(),
+        });
+      } catch (e) {
+        console.error('failed to update positions of', address, 'in', contract, e);
+      }
+    });
   }
 
   async updateAll(blockNumber) {


### PR DESCRIPTION
## Summary
- Adds `GET /api/borrowers/positions` (all known borrowers) and `GET /api/borrowers/positions/:address` (single EVM address). Returns each borrower's per-reserve collateral (aToken balance) and debt (variable + stable debt token balances), with both raw on-chain values and decimal-formatted amounts.
- Positions refresh only on the AAVE events that change them — `Supply` / `Withdraw` / `Borrow` / `Repay` / `LiquidationCall` for the affected user — and not on the oracle-driven `updateAll` sweep. This means RPC traffic for positions scales with user activity, not with block production.
- Uses `getUserConfiguration` to decode the per-user reserve bitmap so only reserves the user actually touches get `balanceOf` calls. Reserve metadata (aToken / variableDebtToken / stableDebtToken addresses + symbol / decimals via `ERC20Mapping`) is fetched once per pool and cached for the process lifetime.

## Test plan
Verified live against Hydration mainnet (`wss://rpc.hydradx.cloud`, block ~12,399,300):
- [x] Bootstrap: 1557 borrowers loaded from Grafana, positions populated, 0 RPC failures
- [x] `GET /api/borrowers/positions` returns 1557 entries (955 with non-empty positions, 696 with debt); all 22 distinct reserves resolved with correct symbols (DOT, vDOT, USDT, USDC, HOLLAR, WBTC, ETH, SOL, EURC, PAXG, PRIME, SIGIL, tBTC, 3-Pool, plus the 2-Pool-G* / 2-Pool-HUSD* aggregator tokens)
- [x] `GET /api/borrowers/positions/:address` correctly returns single-borrower entries; returns `[]` for unknown addresses
- [x] Cross-check: a sample borrower's HOLLAR `variableAmount` (457.817) matches their aggregate `totalDebtBase` (457.817) from `getUserAccountData`
- [x] Bitmap filtering verified: borrowers with 0 to 20 collateral positions, only reserves with set bits are queried
- [x] Live event refresh: observed two `Borrow` events; both borrowers' position entries updated to post-borrow balances with newer `updated` timestamps
- [x] Oracle sweep does not touch positions: position `updated` timestamps stay at bootstrap time during oracle-driven health refreshes
- [x] Existing `/api/borrowers/by-health` and `/api/borrowers/:address` endpoints still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)