### PR TITLE
fix(otc): include only the filler's swap legs, skip the OTC fee transfer

### DIFF
--- a/src/handlers/otc.js
+++ b/src/handlers/otc.js
@@ -19,11 +19,17 @@ async function placedHandler({event, siblings}) {
 
 async function filledHandler({event, siblings}) {
   const {who} = event.data;
+  const whoStr = who.toString();
   const [b, a] = siblings
     .slice(0, siblings.indexOf(event))
     .reverse()
-    .filter(({method}) => method === 'Transfer')
+    .filter(({method, data}) => method === 'Transfer'
+      && (data.from?.toString() === whoStr || data.to?.toString() === whoStr))
     .map(({data}) => ({currencyId: 0, ...data}));
+  if (!a || !b) {
+    console.warn('otc filled: could not find both swap legs for', whoStr);
+    return;
+  }
   const message = `${formatAccount(who)} swapped **${formatAmount(a)}** for **${formatAmount(b)}** OTC`;
   broadcast(message);
 }


### PR DESCRIPTION
## Summary
The OTC `Filled` / `PartiallyFilled` handler picked the last two `Transfer` events emitted before the OTC event, but partial fills emit **three** candidate transfers: the two swap legs plus a fee transfer from the maker to the OTC fee account. Picking the most recent two meant we silently grabbed the fee transfer instead of one swap leg, producing reports like:

> 🦏2ee swapped 41 580 USDC for 41.63 USDC OTC

on a real apyUSD→USDC fill ([block 12467683 ext 2](https://hydration.subscan.io/extrinsic/12467683-2)) — both legs labelled USDC, and the second one is actually the 0.1% fee.

The fix filters `Transfer` events to those where the filler (`who`) is either `from` or `to`. Fee transfers are between the maker and a fee account and never involve the filler, so they are correctly excluded. If both legs aren't found we log a warning and skip the broadcast rather than emit a malformed message.

## Test plan
- [x] Loaded block 12467683 against `wss://rpc.hydradx.cloud` and confirmed the OTC handler now broadcasts `swapped 30 230 apyUSD for 41 580 USDC OTC` (matching the on-chain swap legs at events 6 and 10, ignoring the fee transfer at event 12)
- [ ] (deploy) Watch live OTC fills and confirm the previously-misreported partial fills now show the correct asset pair

🤖 Generated with [Claude Code](https://claude.com/claude-code)