### PR TITLE
Detect factory/CREATE2 contract deployments

### DIFF
--- a/ALERTS.md
+++ b/ALERTS.md
@@ -81,7 +81,9 @@ ALERT_DEPLOYMENT=true
 **Detection:** Rather than relying on `evm.Created` (which Frontier only emits for top-level
 deploys), the watcher inspects every `ethereum.Executed` and flags any touched address whose
 bytecode went from empty to non-empty in that block. This catches factory / CREATE2
-deployments too. When disabled, no extra chain reads are performed.
+deployments too. At init it preseeds the set of already-deployed contracts (from
+`evm.accountCodes`) so calls to existing contracts are skipped without a chain read. When the
+alert is disabled the handler is not registered at all — zero overhead.
 
 ## Complete Configuration Example
 

--- a/ALERTS.md
+++ b/ALERTS.md
@@ -68,7 +68,7 @@ ALERT_PRICE_DELTA='[["GDOT/DOT", "5%", "10m"], ["GDOT/USDT", "10%", "1m"], ["DOT
 
 ### ALERT_DEPLOYMENT (Contract Deployment Monitoring)
 **Type:** boolean toggle (`1` / `true` / `yes` / `on` to enable; unset or anything else disables)
-**Purpose:** Notify on every EVM contract deployment (`evm.Created`) on the chain
+**Purpose:** Notify on every EVM contract deployment on the chain
 
 ```bash
 ALERT_DEPLOYMENT=true
@@ -77,6 +77,11 @@ ALERT_DEPLOYMENT=true
 **Alert Behavior:**
 - **🚨 TRIGGERED**: Fires once per deployed contract with its address and block number
 - No resolution state — each deployment is a standalone notification
+
+**Detection:** Rather than relying on `evm.Created` (which Frontier only emits for top-level
+deploys), the watcher inspects every `ethereum.Executed` and flags any touched address whose
+bytecode went from empty to non-empty in that block. This catches factory / CREATE2
+deployments too. When disabled, no extra chain reads are performed.
 
 ## Complete Configuration Example
 

--- a/src/handlers/deployments.js
+++ b/src/handlers/deployments.js
@@ -1,29 +1,45 @@
 import {api} from "../api.js";
 import {getAlerts} from "../utils/alerts.js";
 
+// Addresses already holding bytecode, so normal calls to them are skipped without a chain
+// read. Seeded once at init from evm.accountCodes and extended as new deploys are seen.
+const knownContracts = new Set();
+
 // Frontier emits evm.Created only for top-level deploys; contracts deployed through a
 // factory / CREATE2 surface as ethereum.Executed + evm.Log with no Created event. Catch
 // every deployment by spotting addresses whose bytecode went from empty to non-empty
 // within the block — covers factory, CREATE2 and top-level alike.
 export default function deploymentHandler(events) {
+  if (!getAlerts().deploymentsEnabled()) return; // alert disabled → don't watch anything
+
   events.on('ethereum', 'Executed', executedHandler);
+  seedKnownContracts().catch(e => console.error('deployment alert: failed to seed known contracts', e));
+}
+
+async function seedKnownContracts() {
+  const keys = await api().query.evm.accountCodes.keys();
+  for (const key of keys) knownContracts.add(key.args[0].toString().toLowerCase());
+  console.log(`deployment alert: seeded ${knownContracts.size} known contracts`);
 }
 
 async function executedHandler({event, siblings, blockNumber, blockHash}) {
-  const alerts = getAlerts();
-  if (!alerts.deploymentsEnabled()) return; // skip the chain reads entirely when disabled
-
   const candidates = candidateAddresses(event, siblings);
   if (!candidates.size) return;
 
-  const parentHash = await api().rpc.chain.getBlockHash(blockNumber - 1);
+  let parentHash;
   for (const address of candidates) {
+    if (knownContracts.has(address)) continue; // deployed before — not news
+
+    parentHash ??= await api().rpc.chain.getBlockHash(blockNumber - 1);
     const [before, after] = await Promise.all([
       api().query.evm.accountCodes.at(parentHash, address),
       api().query.evm.accountCodes.at(blockHash, address),
     ]);
-    if (before.toHex() === '0x' && after.toHex() !== '0x') {
-      await alerts.checkDeployment(address, blockNumber);
+    if (after.toHex() === '0x') continue; // not a contract (EOA / empty call target)
+
+    knownContracts.add(address); // remember so we never re-check it
+    if (before.toHex() === '0x') {
+      await getAlerts().checkDeployment(address, blockNumber);
     }
   }
 }

--- a/src/handlers/deployments.js
+++ b/src/handlers/deployments.js
@@ -1,11 +1,43 @@
+import {api} from "../api.js";
 import {getAlerts} from "../utils/alerts.js";
 
+// Frontier emits evm.Created only for top-level deploys; contracts deployed through a
+// factory / CREATE2 surface as ethereum.Executed + evm.Log with no Created event. Catch
+// every deployment by spotting addresses whose bytecode went from empty to non-empty
+// within the block — covers factory, CREATE2 and top-level alike.
 export default function deploymentHandler(events) {
-  events.on('evm', 'Created', createdHandler);
+  events.on('ethereum', 'Executed', executedHandler);
 }
 
-async function createdHandler({event, blockNumber}) {
-  const {address} = event.data;
+async function executedHandler({event, siblings, blockNumber, blockHash}) {
   const alerts = getAlerts();
-  await alerts.checkDeployment(address.toString(), blockNumber);
+  if (!alerts.deploymentsEnabled()) return; // skip the chain reads entirely when disabled
+
+  const candidates = candidateAddresses(event, siblings);
+  if (!candidates.size) return;
+
+  const parentHash = await api().rpc.chain.getBlockHash(blockNumber - 1);
+  for (const address of candidates) {
+    const [before, after] = await Promise.all([
+      api().query.evm.accountCodes.at(parentHash, address),
+      api().query.evm.accountCodes.at(blockHash, address),
+    ]);
+    if (before.toHex() === '0x' && after.toHex() !== '0x') {
+      await alerts.checkDeployment(address, blockNumber);
+    }
+  }
+}
+
+// EVM addresses touched by this transaction that could be freshly deployed contracts:
+// the call target and any log-emitting contracts in the same extrinsic.
+function candidateAddresses({data: {to}}, siblings) {
+  const addresses = new Set();
+  if (to) addresses.add(to.toString().toLowerCase());
+  for (const {section, method, data} of siblings) {
+    if (section === 'evm' && method === 'Log') {
+      const address = data?.log?.address;
+      if (address) addresses.add(address.toString().toLowerCase());
+    }
+  }
+  return addresses;
 }

--- a/src/utils/alerts.js
+++ b/src/utils/alerts.js
@@ -264,6 +264,10 @@ class Alerts {
     }
   }
 
+  deploymentsEnabled() {
+    return this.alertConfigs.deployment;
+  }
+
   async checkDeployment(address, blockNumber) {
     if (!this.alertConfigs.deployment) return;
 


### PR DESCRIPTION
## Why

The `ALERT_DEPLOYMENT` watcher listened for `evm.Created`, which Frontier emits **only for top-level deploy transactions** (raw tx with `to = null`). Contracts deployed via a **factory / CREATE2** — the common case for scripted/deterministic deploys — never emit it, so those deployments produced no alert.

Confirmed against a real deploy in block `12860846`: it surfaced as `ethereum.Executed` + `evm.Log` with **no `evm.Created`**, and the contract (`0x41f3…`) went from empty bytecode → 4870 bytes.

## What

- Replace the `evm.Created` listener with a **bytecode-transition** detector on `ethereum.Executed`:
  - gather candidate addresses (call target + `evm.Log` emitters in the same extrinsic)
  - flag any whose `evm.accountCodes` went **empty → non-empty** vs the parent block
- Catches factory, CREATE2 **and** top-level deploys in one path.
- `deploymentsEnabled()` short-circuits before any chain reads when the alert is off → zero overhead on instances that don't use it.
- Docs updated.

## Trade-offs

- Adds a couple of `accountCodes` reads per EVM-active block (only when enabled; EVM activity on Hydration is light).
- A contract deployed by a factory that emits **no** constructor logs and isn't the call target wouldn't appear as a candidate (would need EVM tracing to catch). Covers the realistic cases.

## Validation

Simulated the exact handler logic against block `12860846` → correctly flags `0x41f3173d3b49b1ae1452a5d2ccfef7dcfe2b773a` as a deployment. `node --check` passes on changed files.

## Note

Deployment alerts still go only to the `DISCORD_WEBHOOK` channel (via `sendWebhooks`), not the main `broadcast()` feed — unchanged here. Can add main-feed broadcast if wanted.