### PR TITLE
arm watchdog at startup, add /health endpoint

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -16,6 +16,7 @@ import hsm, {submitReport} from "./handlers/hsm.js";
 import circuitbreaker from "./handlers/circuitbreaker.js";
 import deployments from "./handlers/deployments.js";
 import {initDiscord} from "./discord.js";
+import "./health.js";
 import {rpc, sha, token, channel} from "./config.js";
 import {currenciesHandler} from "./currencies.js";
 import {endpoints} from "./endpoints.js";

--- a/src/events.js
+++ b/src/events.js
@@ -1,6 +1,7 @@
 import {api} from './api.js';
 import ethers from "ethers";
 import {delay, timeout} from "./config.js";
+import {recordBlock} from "./health.js";
 import memoize from "memoizee";
 import process from "node:process";
 
@@ -57,9 +58,15 @@ export class Events {
       }, timeout * 1000);
     };
 
+    // arm immediately so a connect-but-never-stream RPC still trips the
+    // watchdog — otherwise it would only ever start ticking after the first
+    // block, leaving the process wedged "running" forever
+    resetWatchdog();
+
     api().query.system.number(head => {
       resetWatchdog();
       const number = head.toNumber() - delay;
+      recordBlock(number);
       this.emitFromBlock(number);
     });
   }

--- a/src/health.js
+++ b/src/health.js
@@ -1,0 +1,30 @@
+import {endpoints} from './endpoints.js';
+import {timeout} from './config.js';
+
+let lastBlockNumber = null;
+let lastBlockAt = null;
+
+export function recordBlock(number) {
+  lastBlockNumber = number;
+  lastBlockAt = Date.now();
+}
+
+export function health() {
+  const ageMs = lastBlockAt === null ? null : Date.now() - lastBlockAt;
+  const healthy = ageMs !== null && ageMs < timeout * 1000;
+  return {
+    healthy,
+    lastBlock: lastBlockNumber,
+    lastBlockAgeSeconds: ageMs === null ? null : Math.round(ageMs / 1000),
+    timeoutSeconds: timeout,
+  };
+}
+
+endpoints.registerEndpoint('health', {
+  '/': {
+    GET: async (req, res) => {
+      const h = health();
+      res.status(h.healthy ? 200 : 503).json({status: h.healthy ? 'ok' : 'stalled', ...h});
+    },
+  },
+}, {prefix: false});


### PR DESCRIPTION
## Why

`snakewatch_hydra` on play was `running` for 3 days while emitting zero logs and posting nothing — wedged, not crashed, so nothing restarted it.

- The block-liveness watchdog (`events.js`) only ever armed its timer **inside** the `system.number` callback → it needs a first block to start ticking.
- An RPC that accepts the WS connection but never streams a head leaves the watchdog unarmed → no SIGTERM → no restart → silent forever.
- No Docker healthcheck existed either, so swarm saw a healthy task.

## Changes

- **Arm the watchdog at startup** (`events.js`) → a connect-but-never-stream RPC now trips the existing `no block for {timeout}s → SIGTERM` path and gets restarted by swarm.
- **`/health` endpoint** (`src/health.js`) on the existing express server (same registry as `/metrics`) → `200 {status:"ok"}` when the last block is younger than `TIMEOUT`s, `503 {status:"stalled"}` otherwise (or before the first block). Block height is recorded from the same subscription callback.

## Adding it to a stack

Per-service in the swarm compose (kept opt-in so the deliberately-dead testnet services aren't force-restarted):

```yaml
    healthcheck:
      test: ["CMD", "wget", "-qO-", "http://localhost:3000/health"]
      interval: 30s
      timeout: 5s
      start_period: 120s
      retries: 3
```

`wget` is present in the `node:18-alpine` base and exits non-zero on the 503, so swarm restarts the task.

## Test

- `node --check` on all touched files.
- Endpoint verified over real HTTP: `503 stalled` before any block, `200 ok` after a recorded block.
