### PR TITLE
GIGAHDX staking events, filter stHDX

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -9,6 +9,7 @@ import transfers from "./handlers/transfers.js";
 import otc from "./handlers/otc.js";
 import dca, {terminator} from "./handlers/dca.js";
 import staking from "./handlers/staking.js";
+import gigahdx from "./handlers/gigahdx.js";
 import referrals from "./handlers/referrals.js";
 import borrowing from "./handlers/borrowing.js";
 import oracle from "./handlers/oracle.js";
@@ -53,6 +54,7 @@ async function main() {
   events.addHandler(dca)
   events.addHandler(transfers);
   events.addHandler(staking);
+  events.addHandler(gigahdx);
   events.addHandler(referrals);
   events.addHandler(borrowing);
   events.addHandler(oracle);

--- a/src/config.js
+++ b/src/config.js
@@ -15,7 +15,7 @@ export const port = process.env.PORT || 3000;
 export const liquidationAlert = Number(process.env.LIQ_ALERT);
 export const priceDivergenceThreshold = Number(process.env.PRICE_DIVERGENCE); // e.g 0.03 = 3%
 export const timeout = Number(process.env.TIMEOUT) || 120;
-export const mute = process.env.MUTE?.split(",") || ['BLAST'];
+export const mute = process.env.MUTE?.split(",") || ['BLAST', 'stHDX'];
 
 export const slackAlertWebhook = process.env.SLACK_ALERT_WEBHOOK;
 export const discordWebhook = process.env.DISCORD_WEBHOOK;

--- a/src/handlers/gigahdx.js
+++ b/src/handlers/gigahdx.js
@@ -1,0 +1,29 @@
+import {formatAccount, formatAmount, hdx} from "../currencies.js";
+import {broadcast} from "../discord.js";
+
+// A migration from legacy staking emits BOTH `Staked` and `MigratedFromLegacy`
+// in the same extrinsic. Suppress the `Staked` message in that case so migrations
+// are only reported once, as a migration.
+const notMigration = ({siblings}) => siblings.find(({section, method}) =>
+  section === 'gigaHdx' && method === 'MigratedFromLegacy') === undefined;
+
+export default function gigahdxHandler(events) {
+  events
+    .onFilter('gigaHdx', 'Staked', notMigration, stakedHandler)
+    .on('gigaHdx', 'MigratedFromLegacy', migratedHandler)
+    .on('gigaHdx', 'Unstaked', unstakedHandler);
+}
+
+const GIGAHDX = '<:GIGAHDX:1521826604924272690>';
+
+async function stakedHandler({event: {data: {who, amount}}}) {
+  broadcast(`${formatAccount(who)} staked **${formatAmount(hdx(amount))}** as GIGAHDX ${GIGAHDX}`);
+}
+
+async function migratedHandler({event: {data: {who, hdxUnlocked}}}) {
+  broadcast(`${formatAccount(who)} migrated **${formatAmount(hdx(hdxUnlocked))}** to GIGAHDX ${GIGAHDX}`);
+}
+
+async function unstakedHandler({event: {data: {who, payout}}}) {
+  broadcast(`${formatAccount(who)} unstaked **${formatAmount(hdx(payout))}** from GIGAHDX :poop:`);
+}


### PR DESCRIPTION
Report GIGAHDX staking activity from the gigaHdx pallet and stop surfacing the internal stHDX money-market legs.

- New gigahdx handler:
  - MigratedFromLegacy -> "migrated <hdxUnlocked> HDX to GIGAHDX"
  - Staked            -> "staked <amount> HDX as GIGAHDX"
  - Unstaked          -> "unstaked <payout> HDX from GIGAHDX"
  A migration emits both Staked and MigratedFromLegacy in the same
  extrinsic, so the Staked leg is suppressed when a MigratedFromLegacy
  sibling exists to avoid double-posting.
- Mute stHDX: staking into GIGAHDX supplies stHDX into the Aave money
  market (and withdraws on unstake); add stHDX to the mute list so
  those "supplied/withdrew stHDX" messages are filtered out.
- Append the GIGAHDX emoji to staked/migrated messages and :poop: to
  unstaked.