### PR TITLE
staking: report GIGAHDX stake/unstake/rewards events

### DIFF
--- a/src/handlers/staking.js
+++ b/src/handlers/staking.js
@@ -1,12 +1,22 @@
-import {formatAccount, formatAmount, hdx} from "../currencies.js";
+import {formatAccount, formatAmount, hdx, loadCurrency} from "../currencies.js";
 import {broadcast} from "../discord.js";
+
+const GIGAHDX_ASSET_ID = 67;
+const asGigaHdx = amount => ({currencyId: GIGAHDX_ASSET_ID, amount});
 
 export default function stakingHandler(events) {
   events
     .on('staking', 'PositionCreated', stakeHandler)
     .on('staking', 'StakeAdded', stakeHandler)
     .on('staking', 'RewardsClaimed', rewardsClaimedHandler)
-    .on('staking', 'Unstaked', unstakeHandler);
+    .on('staking', 'Unstaked', unstakeHandler)
+    .on('gigaHdx', 'Staked', gigaStakedHandler)
+    .on('gigaHdx', 'Unstaked', gigaUnstakedHandler)
+    .on('gigaHdx', 'Unlocked', gigaUnlockedHandler)
+    .on('gigaHdx', 'UnstakeCancelled', gigaUnstakeCancelledHandler)
+    .on('gigaHdx', 'MigratedFromLegacy', gigaMigratedHandler)
+    .on('gigaHdx', 'PoolContractUpdated', gigaPoolContractUpdatedHandler)
+    .on('gigaHdxRewards', 'RewardsClaimed', gigaRewardsClaimedHandler);
 }
 
 async function stakeHandler({event: {data: {who, stake}}}) {
@@ -23,5 +33,37 @@ async function rewardsClaimedHandler({event: {data: {who, paidRewards, unlockedR
   if (totalRewards > 0) {
     const message = `${formatAccount(who)} claimed **${formatAmount(hdx(totalRewards))}** and forfeited **${formatAmount(hdx(slashedUnpaidRewards))}**`;
     broadcast(message);
+  }
+}
+
+async function gigaStakedHandler({event: {data: {who, amount, gigahdx: minted}}}) {
+  await loadCurrency(GIGAHDX_ASSET_ID);
+  broadcast(`${formatAccount(who)} staked **${formatAmount(hdx(amount))}** into GIGAHDX for **${formatAmount(asGigaHdx(minted))}**`);
+}
+
+async function gigaUnstakedHandler({event: {data: {who, payout, expiresAt}}, blockNumber}) {
+  const blocksRemaining = expiresAt.toNumber() - blockNumber;
+  broadcast(`${formatAccount(who)} started unstaking **${formatAmount(hdx(payout))}** from GIGAHDX, unlocks at block #${expiresAt} (~${blocksRemaining} blocks)`);
+}
+
+async function gigaUnlockedHandler({event: {data: {who, amount}}}) {
+  broadcast(`${formatAccount(who)} unstaked **${formatAmount(hdx(amount))}** from GIGAHDX <:cheems:989553853785587723>`);
+}
+
+async function gigaUnstakeCancelledHandler({event: {data: {who, amount}}}) {
+  broadcast(`${formatAccount(who)} cancelled unstaking **${formatAmount(hdx(amount))}** and restaked it in GIGAHDX`);
+}
+
+async function gigaMigratedHandler({event: {data: {who, hdxUnlocked}}}) {
+  broadcast(`${formatAccount(who)} migrated **${formatAmount(hdx(hdxUnlocked))}** from legacy staking into GIGAHDX`);
+}
+
+async function gigaPoolContractUpdatedHandler({event: {data: {contract}}}) {
+  broadcast(`⚠️ GIGAHDX pool contract updated to \`${contract}\``);
+}
+
+async function gigaRewardsClaimedHandler({event: {data: {who, totalHdx}}}) {
+  if (Number(totalHdx) > 0) {
+    broadcast(`${formatAccount(who)} claimed **${formatAmount(hdx(totalHdx))}** governance rewards into GIGAHDX`);
   }
 }


### PR DESCRIPTION
## Why

GigaHDX is Hydration's new staking mechanism (runtime 428, live on-chain now) — locks HDX into an AAVE-style money market, mints a GIGAHDX aToken, and adds governance-vote-weighted reward boosts with a cooldown-gated unstake. Two new pallets (`gigaHdx`, `gigaHdxRewards`) sit alongside the legacy NFT staking pallet snakewatch already reports on.

## Changes

Extended `src/handlers/staking.js` (no new files) to report the GigaHDX lifecycle next to the existing legacy-staking messages:

- `gigaHdx.Staked` → staked into GIGAHDX
- `gigaHdx.Unstaked` → cooldown started, shows unlock block + blocks remaining
- `gigaHdx.Unlocked` → funds released (reuses the existing cheems emoji, same semantic spot as legacy `Unstaked`)
- `gigaHdx.UnstakeCancelled` → re-staked before cooldown finished
- `gigaHdx.MigratedFromLegacy` → migrated from old NFT staking
- `gigaHdx.PoolContractUpdated` → governance changed the AAVE pool address (rare/privileged, flagged with ⚠️)
- `gigaHdxRewards.RewardsClaimed` → governance voting rewards claimed into a stake (zero-payout claims suppressed, mirroring the legacy handler's guard)

Skipped `YieldRealized`, `RewardPoolAllocated`, `UserRewardRecorded` — internal accounting / per-voter noise with no precedent for that granularity in the existing handlers.

## Test

Verified against the live chain (`wss://hdx.tarn.hydration.cloud`) with a throwaway script exercising all 7 handlers — confirmed correct HDX/GIGAHDX symbol+decimal resolution from the real asset registry, correct block-remaining math, and the zero-reward suppression. Script not committed.

Note: didn't add a Jest test — importing anything through `src/discord.js` currently trips Jest's CJS-module-lexer under this repo's `--experimental-vm-modules` setup (a transitive dep of the real `discord.js` package), a pre-existing gap unrelated to this change.
