### PR TITLE
staking: drop minted-GIGAHDX amount from stake message

### DIFF
--- a/src/handlers/staking.js
+++ b/src/handlers/staking.js
@@ -1,8 +1,5 @@
-import {formatAccount, formatAmount, hdx, loadCurrency} from "../currencies.js";
+import {formatAccount, formatAmount, hdx} from "../currencies.js";
 import {broadcast} from "../discord.js";
-
-const GIGAHDX_ASSET_ID = 67;
-const asGigaHdx = amount => ({currencyId: GIGAHDX_ASSET_ID, amount});
 
 export default function stakingHandler(events) {
   events
@@ -36,9 +33,8 @@ async function rewardsClaimedHandler({event: {data: {who, paidRewards, unlockedR
   }
 }
 
-async function gigaStakedHandler({event: {data: {who, amount, gigahdx: minted}}}) {
-  await loadCurrency(GIGAHDX_ASSET_ID);
-  broadcast(`${formatAccount(who)} staked **${formatAmount(hdx(amount))}** into GIGAHDX for **${formatAmount(asGigaHdx(minted))}**`);
+async function gigaStakedHandler({event: {data: {who, amount}}}) {
+  broadcast(`${formatAccount(who)} staked **${formatAmount(hdx(amount))}** into GIGAHDX`);
 }
 
 async function gigaUnstakedHandler({event: {data: {who, payout, expiresAt}}, blockNumber}) {


### PR DESCRIPTION
## Why

Follow-up to #43. The GIGAHDX stake message was showing both the HDX staked and the minted GIGAHDX aToken amount, which is redundant since they're ~1:1.

## Changes

`staked **X HDX** into GIGAHDX for **Y GIGAHDX**` → `staked **X HDX** into GIGAHDX`. Drops the now-unused `GIGAHDX_ASSET_ID`/`asGigaHdx` helper and the `loadCurrency` call that only existed to format that amount.