### PR TITLE
staking: collapse redundant supply/stake messages on migrate and cancel_unstake

### DIFF
--- a/src/handlers/borrowing.js
+++ b/src/handlers/borrowing.js
@@ -14,11 +14,17 @@ const borrowers = new Borrowers();
 const notDusted = ({siblings}) => siblings.find(({section, method}) =>
   section === 'duster' && method === 'Dusted') === undefined;
 
+// stHDX only exists as glue between pallet-gigahdx and the AAVE money market —
+// every supply/withdraw of it is an internal step of a gigahdx action already
+// reported by the staking handlers, never a standalone user action.
+const STHDX_ASSET_ID = 670;
+const notGigaHdxPlumbing = ({log: {args: {reserve}}}) => ERC20Mapping.decodeEvmAddress(reserve) !== STHDX_ASSET_ID;
+
 export default function borrowingHandler(events) {
   borrowers.init();
   events
-    .onLog('Supply', poolAbi, borrowers.handler(supply), notInRouter)
-    .onLog('Withdraw', poolAbi, borrowers.handler(withdraw), e => notInRouter(e) && notDusted(e))
+    .onLog('Supply', poolAbi, borrowers.handler(supply), e => notInRouter(e) && notGigaHdxPlumbing(e))
+    .onLog('Withdraw', poolAbi, borrowers.handler(withdraw), e => notInRouter(e) && notDusted(e) && notGigaHdxPlumbing(e))
     .onLog('Borrow', poolAbi, borrowers.handler(borrow))
     .onLog('Repay', poolAbi, borrowers.handler(repay))
     .onLog('LiquidationCall', poolAbi, borrowers.handler(liquidationCall))

--- a/src/handlers/staking.js
+++ b/src/handlers/staking.js
@@ -33,7 +33,14 @@ async function rewardsClaimedHandler({event: {data: {who, paidRewards, unlockedR
   }
 }
 
-async function gigaStakedHandler({event: {data: {who, amount}}}) {
+// do_stake (which emits Staked) is also called internally by migrate and
+// cancel_unstake — each of those deposits its own, more specific event in the
+// same extrinsic, so skip the generic message and let that one stand alone.
+const isDerivedStake = siblings => siblings.some(({section, method}) =>
+  section === 'gigaHdx' && ['MigratedFromLegacy', 'UnstakeCancelled'].includes(method));
+
+async function gigaStakedHandler({event: {data: {who, amount}}, siblings}) {
+  if (isDerivedStake(siblings)) return;
   broadcast(`${formatAccount(who)} staked **${formatAmount(hdx(amount))}** into GIGAHDX`);
 }
 


### PR DESCRIPTION
## Why

`migrate` and `cancel_unstake` both call `do_stake` internally (same as a plain `giga_stake`), which deposits its own `Staked` event on top of the AAVE `Supply` log for stHDX. Combined with each call's own specific event, that produced 3 broadcasts for one action:

```
🐽NrG supplied 136 000 stHDX
🐽NrG staked 136 100 HDX into GIGAHDX
🐽NrG migrated 136 100 HDX from legacy staking into GIGAHDX
```

Only the last line is meaningful — the first two are internal plumbing of the same call.

## Changes

- `staking.js`: `gigaStakedHandler` now skips broadcasting when the `Staked` event's siblings include `MigratedFromLegacy` or `UnstakeCancelled` (same extrinsic, more specific event already covers it).
- `borrowing.js`: the generic AAVE `Supply`/`Withdraw` broadcasts now skip stHDX (asset 670) — it only exists as glue between `pallet-gigahdx` and the money market, per the pallet's own doc comment ("mint/burn exclusive to pallet-gigahdx"), so it's never a standalone user action worth reporting.

Result:
- Migration → only `migrated ... from legacy staking into GIGAHDX`.
- Plain `giga_stake` → only `staked ... into GIGAHDX` (unaffected, no siblings to match).
- `cancel_unstake` gets the same fix (identical redundant-triplet pattern, not separately reported but same root cause).

## Test

Verified against the live chain with synthetic sibling payloads for all three paths (plain stake, migrate, cancel_unstake) — each collapses to exactly the expected single message.