### PR TITLE
staking: mute stHDX via config, use real GIGAHDX emoji

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -17,7 +17,7 @@ export const port = process.env.PORT || 3000;
 export const liquidationAlert = Number(process.env.LIQ_ALERT);
 export const priceDivergenceThreshold = Number(process.env.PRICE_DIVERGENCE); // e.g 0.03 = 3%
 export const timeout = Number(process.env.TIMEOUT) || 120;
-export const mute = process.env.MUTE?.split(",") || ['BLAST'];
+export const mute = process.env.MUTE?.split(",") || ['BLAST', 'stHDX'];
 
 export const slackAlertWebhook = process.env.SLACK_ALERT_WEBHOOK;
 // JSON array of webhook URLs; falls back to wrapping the legacy single webhook

--- a/src/handlers/borrowing.js
+++ b/src/handlers/borrowing.js
@@ -14,17 +14,11 @@ const borrowers = new Borrowers();
 const notDusted = ({siblings}) => siblings.find(({section, method}) =>
   section === 'duster' && method === 'Dusted') === undefined;
 
-// stHDX only exists as glue between pallet-gigahdx and the AAVE money market —
-// every supply/withdraw of it is an internal step of a gigahdx action already
-// reported by the staking handlers, never a standalone user action.
-const STHDX_ASSET_ID = 670;
-const notGigaHdxPlumbing = ({log: {args: {reserve}}}) => ERC20Mapping.decodeEvmAddress(reserve) !== STHDX_ASSET_ID;
-
 export default function borrowingHandler(events) {
   borrowers.init();
   events
-    .onLog('Supply', poolAbi, borrowers.handler(supply), e => notInRouter(e) && notGigaHdxPlumbing(e))
-    .onLog('Withdraw', poolAbi, borrowers.handler(withdraw), e => notInRouter(e) && notDusted(e) && notGigaHdxPlumbing(e))
+    .onLog('Supply', poolAbi, borrowers.handler(supply), notInRouter)
+    .onLog('Withdraw', poolAbi, borrowers.handler(withdraw), e => notInRouter(e) && notDusted(e))
     .onLog('Borrow', poolAbi, borrowers.handler(borrow))
     .onLog('Repay', poolAbi, borrowers.handler(repay))
     .onLog('LiquidationCall', poolAbi, borrowers.handler(liquidationCall))

--- a/src/handlers/staking.js
+++ b/src/handlers/staking.js
@@ -1,6 +1,8 @@
 import {formatAccount, formatAmount, hdx} from "../currencies.js";
 import {broadcast} from "../discord.js";
 
+const GIGAHDX = '<:GIGAHDX:1521826604924272690>';
+
 export default function stakingHandler(events) {
   events
     .on('staking', 'PositionCreated', stakeHandler)
@@ -41,12 +43,12 @@ const isDerivedStake = siblings => siblings.some(({section, method}) =>
 
 async function gigaStakedHandler({event: {data: {who, amount}}, siblings}) {
   if (isDerivedStake(siblings)) return;
-  broadcast(`${formatAccount(who)} staked **${formatAmount(hdx(amount))}** into GIGAHDX`);
+  broadcast(`${formatAccount(who)} staked **${formatAmount(hdx(amount))}** into GIGAHDX ${GIGAHDX}`);
 }
 
 async function gigaUnstakedHandler({event: {data: {who, payout, expiresAt}}, blockNumber}) {
   const blocksRemaining = expiresAt.toNumber() - blockNumber;
-  broadcast(`${formatAccount(who)} started unstaking **${formatAmount(hdx(payout))}** from GIGAHDX, unlocks at block #${expiresAt} (~${blocksRemaining} blocks)`);
+  broadcast(`${formatAccount(who)} started unstaking **${formatAmount(hdx(payout))}** from GIGAHDX ${GIGAHDX}, unlocks at block #${expiresAt} (~${blocksRemaining} blocks)`);
 }
 
 async function gigaUnlockedHandler({event: {data: {who, amount}}}) {
@@ -54,11 +56,11 @@ async function gigaUnlockedHandler({event: {data: {who, amount}}}) {
 }
 
 async function gigaUnstakeCancelledHandler({event: {data: {who, amount}}}) {
-  broadcast(`${formatAccount(who)} cancelled unstaking **${formatAmount(hdx(amount))}** and restaked it in GIGAHDX`);
+  broadcast(`${formatAccount(who)} cancelled unstaking **${formatAmount(hdx(amount))}** and restaked it in GIGAHDX ${GIGAHDX}`);
 }
 
 async function gigaMigratedHandler({event: {data: {who, hdxUnlocked}}}) {
-  broadcast(`${formatAccount(who)} migrated **${formatAmount(hdx(hdxUnlocked))}** from legacy staking into GIGAHDX`);
+  broadcast(`${formatAccount(who)} migrated **${formatAmount(hdx(hdxUnlocked))}** from legacy staking into GIGAHDX ${GIGAHDX}`);
 }
 
 async function gigaPoolContractUpdatedHandler({event: {data: {contract}}}) {
@@ -67,6 +69,6 @@ async function gigaPoolContractUpdatedHandler({event: {data: {contract}}}) {
 
 async function gigaRewardsClaimedHandler({event: {data: {who, totalHdx}}}) {
   if (Number(totalHdx) > 0) {
-    broadcast(`${formatAccount(who)} claimed **${formatAmount(hdx(totalHdx))}** governance rewards into GIGAHDX`);
+    broadcast(`${formatAccount(who)} claimed **${formatAmount(hdx(totalHdx))}** governance rewards into GIGAHDX ${GIGAHDX}`);
   }
 }


### PR DESCRIPTION
## Why

Follow-up to #43/#44/#45, after comparing against PR #42 (closed, alternative impl by @lolmcshizz).

The #45 fix filtered stHDX Supply/Withdraw AAVE-log events at the `onLog` level to stop the redundant "supplied X stHDX" broadcasts. That was wrong: `Borrowers.handler()` wraps those callbacks to *also* refresh the account's AAVE health-factor/liquidation tracking (`utils/borrowers.js:108-124`), independent of whether anything gets broadcast. Filtering the event at that level silently skipped health-factor refreshes for gigahdx stakers whenever they stake/unstake without another AAVE action in the same block — a real gap in the liquidation-alert system.

PR #42 had the right idea: mute the text, don't skip the event. It adds `'stHDX'` to the default `mute` list (already checked by `discord.js`'s `broadcast()`), so the Supply/Withdraw handler still runs in full — health tracking stays intact — only the outgoing Discord text is suppressed.

## Changes

- `borrowing.js`: revert the `onLog` filter from #45 (byte-identical to before).
- `config.js`: default `mute` list is now `['BLAST', 'stHDX']`.
- `staking.js`: adopt the real custom Discord emoji `<:GIGAHDX:1521826604924272690>` (used in #42) in place of plain "GIGAHDX" text.

Kept from this PR's broader scope vs #42 (still more correct/complete):
- `Unstaked` (cooldown starts) vs `Unlocked` (funds actually released) are handled as distinct events — #42 only handled `Unstaked` and treated it as if it were completion, mislabeling the moment and never surfacing the real release event.
- `UnstakeCancelled`, `PoolContractUpdated` (governance/security-relevant), and `gigaHdxRewards.RewardsClaimed` are still covered.

## Test

Re-ran the same live-chain verification as #43/#45 (plain stake, migrate, unstake/unlock/cancel) — confirmed messages render with the real emoji and the migrate-collapse logic is unaffected.