### PR TITLE
referrals: track gigahdx fee-processor pots in 'bought for rewards'

### DIFF
--- a/src/handlers/omnipool.js
+++ b/src/handlers/omnipool.js
@@ -3,11 +3,11 @@ import {formatAccount, formatAmount, formatUsdValue, isWhale, usdValue} from "..
 import {broadcast} from "../discord.js";
 import {usdCurrencyId} from "../config.js";
 import {notInRouter} from "./router.js";
-import {notByReferralPot} from "./referrals.js";
+import {notByRewardPot} from "./referrals.js";
 
 export default function omnipoolHandler(events) {
   events
-    .onFilter('omnipool', 'SellExecuted', e => notInRouter(e) && notByReferralPot(e), sellHandler)
+    .onFilter('omnipool', 'SellExecuted', e => notInRouter(e) && notByRewardPot(e), sellHandler)
     .onFilter('omnipool', 'BuyExecuted', notInRouter, buyHandler)
     .on('omnipool', 'LiquidityAdded', liquidityAddedHandler)
     .on('omnipool', 'LiquidityRemoved', liquidityRemovedHandler);

--- a/src/handlers/referrals.js
+++ b/src/handlers/referrals.js
@@ -5,17 +5,21 @@ import {isSameAccount} from "../utils/emojify.js";
 
 export default function referralsHandler(events) {
   events
-    .onFilter('balances', 'Transfer', ({event: {data: {to}}}) => isReferralPot(to.toString()), transferHandler)
+    .onFilter('balances', 'Transfer', ({event: {data: {to}}}) => isRewardPot(to.toString()), transferHandler)
 }
 
-const referralPots = [
+const rewardPots = [
   '7L53bUTCCAvmCxhe15maHwJZbjQYH89LkXuyTnTi1J58xyFC',
   '13UVJyLkaPAE2HDTAaSadmwptPVwzY621KiKZ1ZrKYaXga2w',
+  // pallet_fee_processor's GigaHdxFeeReceiver (15% of trade fees) -> pallet_gigahdx::gigapot_account_id()
+  '12BMz7GAi6ZCN8JiDQ6u7gPX5i71LmVT3vY3qd2ieXvTLAxa',
+  // pallet_fee_processor's GigaHdxRewardsFeeReceiver (25% of trade fees) -> pallet_gigahdx_rewards::reward_accumulator_pot()
+  '167K5HduwPxdgUk2TYTvzAJf4QETArrLz11uT4L6rCAMAkBi',
 ];
 
-const isReferralPot = address => referralPots.some(pot => isSameAccount(address, pot));
+const isRewardPot = address => rewardPots.some(pot => isSameAccount(address, pot));
 
-export const notByReferralPot = ({event: {data: {who}}}) => !isReferralPot(who.toString());
+export const notByRewardPot = ({event: {data: {who}}}) => !isRewardPot(who.toString());
 
 const window = 150;
 let accrued = 0;


### PR DESCRIPTION
## Why

The "💸 X HDX bought for rewards" message (`referrals.js`) only watched two hardcoded pot addresses. Traced the actual on-chain fee flow: `pallet-fee-processor` (new in the same release as gigahdx) splits trade fees across four destinations — 15% to `pallet_gigahdx::gigapot_account_id()`, 25% to `pallet_gigahdx_rewards::reward_accumulator_pot()`, 5%+5% to the legacy staking pot, 5% to the referrals pot. Neither gigahdx destination matched the two tracked addresses — 40% of trade-fee buyback volume had zero visibility.

## Changes

- Added the two gigahdx pot addresses (derived and verified live on-chain via `blake2_256(b"modl" ++ palletId)`, matching `pallet_gigahdx::gigapot_account_id()` and `pallet_gigahdx_rewards::reward_accumulator_pot()`) to the tracked pot list.
- Renamed `referralPots`/`isReferralPot`/`notByReferralPot` → `rewardPots`/`isRewardPot`/`notByRewardPot` since the list is no longer referral-specific. Updated the one consumer (`omnipool.js`).

## Test

Verified against the live chain: all four pot addresses (2 legacy + 2 gigahdx) correctly match the filter; an unrelated address correctly doesn't.