### PR TITLE
oracleprices: timeout and backoff spot-price lookups to stop wedging on a bad pair

### DIFF
--- a/src/utils/oracleprices.js
+++ b/src/utils/oracleprices.js
@@ -14,11 +14,21 @@ import Grafana from "./grafana.js";
 import { grafanaUrl, grafanaDatasource } from "../config.js";
 import {getAlerts} from "./alerts.js";
 
+// The router's WASM math (@galacticcouncil/math-omnipool) can panic on certain
+// pool states (seen for one pair with a "RuntimeError: unreachable" that never
+// returns control to the event loop, wedging the whole process). A JS-level
+// timeout can't preempt a synchronous hang, but it does protect the far more
+// common case of a slow-but-eventually-resolving call, and the backoff stops a
+// pair that just failed from being retried again on literally the next block.
+const SPOT_PRICE_TIMEOUT_MS = 5_000;
+const SPOT_PRICE_BACKOFF_MS = 5 * 60_000;
+
 export default class OraclePrices {
   constructor(priceDivergenceThreshold) {
     this.prices = {};
     this.lastGlobalUpdate = -1;
     this.queue = new PQueue({concurrency: 20, timeout: 10000});
+    this.spotPriceBackoffUntil = new Map();
     this.priceDivergenceThreshold = priceDivergenceThreshold;
 
     this.metrics = metrics.register('oracleprices', {
@@ -316,8 +326,19 @@ export default class OraclePrices {
 
   // Helper to get spot price from router
   async getSpotPrice(baseAssetId, quoteAssetId) {
+    const pairKey = `${baseAssetId}/${quoteAssetId}`;
+    const backoffUntil = this.spotPriceBackoffUntil.get(pairKey);
+    if (backoffUntil && Date.now() < backoffUntil) {
+      return null;
+    }
+
     try {
-      const tradeInfo = await sdk().getBestSpotPrice(baseAssetId, quoteAssetId);
+      const tradeInfo = await Promise.race([
+        sdk().getBestSpotPrice(baseAssetId, quoteAssetId),
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error(`spot price timeout after ${SPOT_PRICE_TIMEOUT_MS}ms`)), SPOT_PRICE_TIMEOUT_MS)),
+      ]);
+      this.spotPriceBackoffUntil.delete(pairKey);
 
       if (!tradeInfo) {
         return null;
@@ -333,6 +354,7 @@ export default class OraclePrices {
         return null;
       }
     } catch (e) {
+      this.spotPriceBackoffUntil.set(pairKey, Date.now() + SPOT_PRICE_BACKOFF_MS);
       console.error(`Failed to get spot price for ${baseAssetId}/${quoteAssetId}:`, e);
       return null;
     }


### PR DESCRIPTION
## Why

`snakewatch_hydra_gc` wedged completely for ~1.5h (silent, no block logs at all, `/health` unreachable) after `getSpotPrice` hit a pair whose router calculation panics inside the WASM math lib (`@galacticcouncil/math-omnipool`'s `recalculate_protocol_fee`, `RuntimeError: unreachable`). That panic never returned control to the event loop, so nothing else — block watching, Discord broadcasting, the existing watchdog timer — could run either. Docker/Swarm never restarted it because the process never exited, just sat permanently busy.

Two gaps in `oracleprices.js` let this happen:
- `updateAll()` (runs on every block via `oracle.js`'s `broadcast` handler — the hottest path) calls `getSpotPrice` directly, bypassing even the existing `PQueue` timeout that protects the other three call sites.
- `getSpotPrice` itself has no timeout or backoff, so a broken pair gets retried on literally every subsequent block forever.

## Changes

- `getSpotPrice` now races the router call against a 5s timeout.
- On failure (timeout or thrown error), the pair goes into a 5-minute backoff — subsequent calls for that pair return `null` immediately instead of re-invoking the router, until the backoff expires.

This can't fully prevent the underlying WASM panic (a JS-level timeout can't preempt a truly synchronous, non-yielding hang once it's already started), but it means:
- the far more common "slow but eventually resolves" failures recover cleanly instead of stalling that call site, and
- a pair that does trigger the panic isn't hammered again on every single block afterward.

Follow-up (tracked separately, infra not code): wiring up the Docker healthcheck against the existing `/health` endpoint so Swarm auto-restarts the container if the event loop ever locks up again, regardless of cause.

## Test

Verified the timeout/backoff mechanism in isolation with a standalone script mirroring the exact logic: a permanently-hung call times out at the configured threshold instead of hanging forever; an immediate retry of the same pair is skipped (backoff, no re-invocation); after the backoff window it retries and succeeds; an unrelated pair is unaffected throughout.