### PR TITLE
bil: watch the vault lifecycle and 2-Pool-BIL swaps

### DIFF
--- a/ALERTS.md
+++ b/ALERTS.md
@@ -85,6 +85,26 @@ deployments too. At init it preseeds the set of already-deployed contracts (from
 `evm.accountCodes`) so calls to existing contracts are skipped without a chain read. When the
 alert is disabled the handler is not registered at all — zero overhead.
 
+### ALERT_BIL (BIL Vault + 2-Pool-BIL Feed)
+**Type:** boolean toggle (`1` / `true` / `yes` / `on` to enable; unset or anything else disables)
+**Purpose:** Report BIL activity to Discord — the BIL vault lifecycle plus swaps in the
+2-Pool-BIL stableswap.
+
+```bash
+ALERT_BIL=true
+```
+
+**What it reports:**
+- **Vault lifecycle** (ERC-4626 / ERC-7540 vault at `0x6a21891Db0940491603f3ccA0a9f4DBA4c6E810C`):
+  deposits, redemption requests, redemptions fulfilled / partially filled, cancellations, and
+  settled claims. HOLLAR amounts are shown as HOLLAR (asset 222); share amounts as uBIL (asset 550).
+- **2-Pool-BIL swaps** (stableswap pool `10055`, assets BIL=55 / HOLLAR=222). When enabled these
+  swaps are reported by the BIL feed and skipped by the generic stableswap handler so they post
+  once; when disabled the generic handler reports them as usual.
+
+**Behavior:** Discord broadcast only (like the borrowing / stableswap feeds), not the Slack alert
+subsystem. When the toggle is off the handler registers nothing — zero overhead.
+
 ## Complete Configuration Example
 
 ```bash

--- a/ALERTS.md
+++ b/ALERTS.md
@@ -85,25 +85,20 @@ deployments too. At init it preseeds the set of already-deployed contracts (from
 `evm.accountCodes`) so calls to existing contracts are skipped without a chain read. When the
 alert is disabled the handler is not registered at all — zero overhead.
 
-### ALERT_BIL (BIL Vault + 2-Pool-BIL Feed)
-**Type:** boolean toggle (`1` / `true` / `yes` / `on` to enable; unset or anything else disables)
+### BIL Vault + 2-Pool-BIL Feed
+**Type:** always on (no configuration)
 **Purpose:** Report BIL activity to Discord — the BIL vault lifecycle plus swaps in the
 2-Pool-BIL stableswap.
-
-```bash
-ALERT_BIL=true
-```
 
 **What it reports:**
 - **Vault lifecycle** (ERC-4626 / ERC-7540 vault at `0x6a21891Db0940491603f3ccA0a9f4DBA4c6E810C`):
   deposits, redemption requests, redemptions fulfilled / partially filled, cancellations, and
   settled claims. HOLLAR amounts are shown as HOLLAR (asset 222); share amounts as uBIL (asset 550).
-- **2-Pool-BIL swaps** (stableswap pool `10055`, assets BIL=55 / HOLLAR=222). When enabled these
-  swaps are reported by the BIL feed and skipped by the generic stableswap handler so they post
-  once; when disabled the generic handler reports them as usual.
+- **2-Pool-BIL swaps** (stableswap pool `10055`, assets BIL=55 / HOLLAR=222). These swaps are
+  reported by the BIL feed and skipped by the generic stableswap handler so they post exactly once.
 
 **Behavior:** Discord broadcast only (like the borrowing / stableswap feeds), not the Slack alert
-subsystem. When the toggle is off the handler registers nothing — zero overhead.
+subsystem. Always registered — no toggle.
 
 ## Complete Configuration Example
 

--- a/src/bot.js
+++ b/src/bot.js
@@ -15,6 +15,7 @@ import oracle from "./handlers/oracle.js";
 import hsm, {submitReport} from "./handlers/hsm.js";
 import circuitbreaker from "./handlers/circuitbreaker.js";
 import deployments from "./handlers/deployments.js";
+import bil from "./handlers/bil.js";
 import {initDiscord} from "./discord.js";
 import "./health.js";
 import {rpc, sha, token, channel} from "./config.js";
@@ -61,6 +62,7 @@ async function main() {
   events.addHandler(hsm);
   events.addHandler(circuitbreaker);
   events.addHandler(deployments);
+  events.addHandler(bil);
 
   if (process.env.NODE_ENV === 'test') {
     console.log('testing mode: pushing testing blocks');

--- a/src/config.js
+++ b/src/config.js
@@ -28,4 +28,3 @@ export const slackAlertHF = process.env.ALERT_HF;
 export const slackAlertRate = process.env.ALERT_RATE;
 export const slackAlertPriceDelta = process.env.ALERT_PRICE_DELTA;
 export const alertDeployment = process.env.ALERT_DEPLOYMENT; // truthy ("1"/"true"/"yes"/"on") to notify on every contract deployment
-export const alertBil = process.env.ALERT_BIL; // truthy ("1"/"true"/"yes"/"on") to enable the BIL vault + 2-Pool-BIL feed

--- a/src/config.js
+++ b/src/config.js
@@ -28,3 +28,4 @@ export const slackAlertHF = process.env.ALERT_HF;
 export const slackAlertRate = process.env.ALERT_RATE;
 export const slackAlertPriceDelta = process.env.ALERT_PRICE_DELTA;
 export const alertDeployment = process.env.ALERT_DEPLOYMENT; // truthy ("1"/"true"/"yes"/"on") to notify on every contract deployment
+export const alertBil = process.env.ALERT_BIL; // truthy ("1"/"true"/"yes"/"on") to enable the BIL vault + 2-Pool-BIL feed

--- a/src/handlers/bil.js
+++ b/src/handlers/bil.js
@@ -3,7 +3,6 @@ import {broadcast} from "../discord.js";
 import {swapHandler} from "./xyk.js";
 import {toAccount} from "../utils/evm.js";
 import bilVaultAbi from "../resources/bil-vault.abi.js";
-import {alertBil} from "../config.js";
 import {notInRouter} from "./router.js";
 
 // BIL vault (ERC-4626 / ERC-7540 HOLLAR wrapper) EVM address on Hydration.
@@ -16,14 +15,10 @@ export const BIL_POOL_ID = 10055;
 const HOLLAR = 222;
 const UBIL = 550;
 
-// Default off; opt in with ALERT_BIL=1|true|yes|on.
-export const bilEnabled = /^(1|true|yes|on)$/i.test(String(alertBil ?? '').trim());
-
 // Hands 2-Pool-BIL swaps from the generic stableswap handler to this feed
-// without double-posting — mirrors the isHsm carve-out. Only claims the pool
-// while the feed is actually enabled, so default behaviour is unchanged.
+// without double-posting — mirrors the isHsm carve-out.
 export function isBilSwap({event}) {
-  return bilEnabled && Number(event.data.poolId) === BIL_POOL_ID;
+  return Number(event.data.poolId) === BIL_POOL_ID;
 }
 
 const atVault = ({event: {data: {log}}}) => log.address.toString().toLowerCase() === VAULT_ADDRESS;
@@ -32,8 +27,6 @@ const hollar = amount => ({currencyId: HOLLAR, amount});
 const ubil = amount => ({currencyId: UBIL, amount});
 
 export default function bilHandler(events) {
-  if (!bilEnabled) return; // feed disabled → register nothing
-
   // Pull the vault underlying + share into the currency cache; they only move
   // via evm.Log so currenciesHandler never sees them.
   Promise.all([HOLLAR, UBIL].map(loadCurrency)).catch(() => {});

--- a/src/handlers/bil.js
+++ b/src/handlers/bil.js
@@ -1,0 +1,97 @@
+import {formatAccount, formatAsset, loadCurrency} from "../currencies.js";
+import {broadcast} from "../discord.js";
+import {swapHandler} from "./xyk.js";
+import {toAccount} from "../utils/evm.js";
+import bilVaultAbi from "../resources/bil-vault.abi.js";
+import {alertBil} from "../config.js";
+import {notInRouter} from "./router.js";
+
+// BIL vault (ERC-4626 / ERC-7540 HOLLAR wrapper) EVM address on Hydration.
+export const VAULT_ADDRESS = '0x6a21891db0940491603f3cca0a9f4dba4c6e810c';
+// 2-Pool-BIL stableswap pool id (assets: BIL=55, HOLLAR=222).
+export const BIL_POOL_ID = 10055;
+
+// Hydration asset ids the feed formats amounts as. HOLLAR is the vault
+// underlying; uBIL (550) is the vault share the events count in.
+const HOLLAR = 222;
+const UBIL = 550;
+
+// Default off; opt in with ALERT_BIL=1|true|yes|on.
+export const bilEnabled = /^(1|true|yes|on)$/i.test(String(alertBil ?? '').trim());
+
+// Hands 2-Pool-BIL swaps from the generic stableswap handler to this feed
+// without double-posting — mirrors the isHsm carve-out. Only claims the pool
+// while the feed is actually enabled, so default behaviour is unchanged.
+export function isBilSwap({event}) {
+  return bilEnabled && Number(event.data.poolId) === BIL_POOL_ID;
+}
+
+const atVault = ({event: {data: {log}}}) => log.address.toString().toLowerCase() === VAULT_ADDRESS;
+
+const hollar = amount => ({currencyId: HOLLAR, amount});
+const ubil = amount => ({currencyId: UBIL, amount});
+
+export default function bilHandler(events) {
+  if (!bilEnabled) return; // feed disabled → register nothing
+
+  // Pull the vault underlying + share into the currency cache; they only move
+  // via evm.Log so currenciesHandler never sees them.
+  Promise.all([HOLLAR, UBIL].map(loadCurrency)).catch(() => {});
+
+  events
+    .onLog('Deposited', bilVaultAbi, deposited, atVault)
+    .onLog('RedemptionRequested', bilVaultAbi, redemptionRequested, atVault)
+    .onLog('RedemptionFulfilled', bilVaultAbi, redemptionFulfilled, atVault)
+    .onLog('RedemptionPartiallyFulfilled', bilVaultAbi, redemptionPartiallyFulfilled, atVault)
+    .onLog('RedemptionCancelled', bilVaultAbi, redemptionCancelled, atVault)
+    .onLog('Withdraw', bilVaultAbi, withdraw, atVault)
+    .onFilter('stableswap', 'SellExecuted', e => notInRouter(e) && isBilSwap(e), bilSwap)
+    .onFilter('stableswap', 'BuyExecuted', e => notInRouter(e) && isBilSwap(e), bilSwap);
+}
+
+async function deposited({log: {args: {user, hollarAmount, bilMinted}}}) {
+  await Promise.all([HOLLAR, UBIL].map(loadCurrency));
+  const account = await toAccount(user);
+  const message = `🇧🇷 ${formatAccount(account)} deposited ${await formatAsset(hollar(hollarAmount))} into the BIL vault for ${await formatAsset(ubil(bilMinted))}`;
+  broadcast(message);
+}
+
+async function redemptionRequested({log: {args: {requestId, user, bilAmount}}}) {
+  await loadCurrency(UBIL);
+  const account = await toAccount(user);
+  const message = `🇧🇷 ${formatAccount(account)} requested BIL redemption #${requestId.toString()} of ${await formatAsset(ubil(bilAmount))}`;
+  broadcast(message);
+}
+
+async function redemptionFulfilled({log: {args}}) {
+  await settled(args, 'fulfilled');
+}
+
+async function redemptionPartiallyFulfilled({log: {args}}) {
+  await settled(args, 'partially filled');
+}
+
+async function settled({requestId, user, hollarAmount, bilBurned}, verb) {
+  await Promise.all([HOLLAR, UBIL].map(loadCurrency));
+  const account = await toAccount(user);
+  const message = `🇧🇷 BIL redemption #${requestId.toString()} ${verb} for ${formatAccount(account)}: ${await formatAsset(ubil(bilBurned))} → ${await formatAsset(hollar(hollarAmount))}`;
+  broadcast(message);
+}
+
+async function redemptionCancelled({log: {args: {requestId, bilReturned}}}) {
+  await loadCurrency(UBIL);
+  const message = `🇧🇷 BIL redemption #${requestId.toString()} cancelled, ${await formatAsset(ubil(bilReturned))} returned`;
+  broadcast(message);
+}
+
+async function withdraw({log: {args: {receiver, assets, shares}}}) {
+  await Promise.all([HOLLAR, UBIL].map(loadCurrency));
+  const account = await toAccount(receiver);
+  const message = `🇧🇷 ${formatAccount(account)} claimed ${await formatAsset(hollar(assets))} from the BIL vault, burning ${await formatAsset(ubil(shares))}`;
+  broadcast(message);
+}
+
+function bilSwap({event}) {
+  const {who, assetIn, assetOut, amountIn, amountOut} = event.data;
+  return swapHandler({who, assetIn, assetOut, amountIn, amountOut});
+}

--- a/src/handlers/stableswap.js
+++ b/src/handlers/stableswap.js
@@ -4,11 +4,12 @@ import {formatAccount, formatAmount, formatUsdValue, isWhale, usdValue} from "..
 import {broadcast} from "../discord.js";
 import {notInRouter} from "./router.js";
 import {isHsm} from "./hsm.js";
+import {isBilSwap} from "./bil.js";
 
 export default function stableswapHandler(events) {
   events
-    .onFilter('stableswap', 'SellExecuted', notInRouter, sellHandler)
-    .onFilter('stableswap', 'BuyExecuted', e => notInRouter(e) && !isHsm(e), buyHandler)
+    .onFilter('stableswap', 'SellExecuted', e => notInRouter(e) && !isBilSwap(e), sellHandler)
+    .onFilter('stableswap', 'BuyExecuted', e => notInRouter(e) && !isHsm(e) && !isBilSwap(e), buyHandler)
     .onFilter('stableswap', 'LiquidityAdded', notInRouter, liquidityAddedHandler)
     .onFilter('stableswap', 'LiquidityRemoved', notInRouter, liquidityRemovedHandler);
 }

--- a/src/resources/bil-vault.abi.js
+++ b/src/resources/bil-vault.abi.js
@@ -1,0 +1,71 @@
+// Event-only ABI for the BIL vault (ERC-4626 / ERC-7540 wrapper around
+// Decentral Protocol positions). Only the lifecycle events the BIL feed
+// reports are declared. `RedemptionFulfilled` / `RedemptionPartiallyFulfilled`
+// are emitted under DELEGATECALL from QueueLib but still logged at the vault's
+// own address, so they parse and address-filter exactly like the rest.
+export default [
+  {
+    anonymous: false,
+    name: 'Deposited',
+    type: 'event',
+    inputs: [
+      {indexed: true, internalType: 'address', name: 'user', type: 'address'},
+      {indexed: false, internalType: 'uint256', name: 'hollarAmount', type: 'uint256'},
+      {indexed: false, internalType: 'uint256', name: 'bilMinted', type: 'uint256'},
+      {indexed: false, internalType: 'uint256', name: 'tokenId', type: 'uint256'},
+    ],
+  },
+  {
+    anonymous: false,
+    name: 'RedemptionRequested',
+    type: 'event',
+    inputs: [
+      {indexed: true, internalType: 'uint256', name: 'requestId', type: 'uint256'},
+      {indexed: true, internalType: 'address', name: 'user', type: 'address'},
+      {indexed: false, internalType: 'uint256', name: 'bilAmount', type: 'uint256'},
+    ],
+  },
+  {
+    anonymous: false,
+    name: 'RedemptionFulfilled',
+    type: 'event',
+    inputs: [
+      {indexed: true, internalType: 'uint256', name: 'requestId', type: 'uint256'},
+      {indexed: true, internalType: 'address', name: 'user', type: 'address'},
+      {indexed: false, internalType: 'uint256', name: 'hollarAmount', type: 'uint256'},
+      {indexed: false, internalType: 'uint256', name: 'bilBurned', type: 'uint256'},
+    ],
+  },
+  {
+    anonymous: false,
+    name: 'RedemptionPartiallyFulfilled',
+    type: 'event',
+    inputs: [
+      {indexed: true, internalType: 'uint256', name: 'requestId', type: 'uint256'},
+      {indexed: true, internalType: 'address', name: 'user', type: 'address'},
+      {indexed: false, internalType: 'uint256', name: 'hollarAmount', type: 'uint256'},
+      {indexed: false, internalType: 'uint256', name: 'bilBurned', type: 'uint256'},
+    ],
+  },
+  {
+    anonymous: false,
+    name: 'RedemptionCancelled',
+    type: 'event',
+    inputs: [
+      {indexed: true, internalType: 'uint256', name: 'requestId', type: 'uint256'},
+      {indexed: false, internalType: 'uint256', name: 'bilReturned', type: 'uint256'},
+    ],
+  },
+  {
+    anonymous: false,
+    name: 'Withdraw',
+    type: 'event',
+    inputs: [
+      {indexed: true, internalType: 'address', name: 'sender', type: 'address'},
+      {indexed: true, internalType: 'address', name: 'receiver', type: 'address'},
+      {indexed: true, internalType: 'address', name: 'owner', type: 'address'},
+      {indexed: false, internalType: 'uint256', name: 'assets', type: 'uint256'},
+      {indexed: false, internalType: 'uint256', name: 'shares', type: 'uint256'},
+    ],
+  },
+];

--- a/tests/bil.test.js
+++ b/tests/bil.test.js
@@ -1,0 +1,52 @@
+import ethers from "ethers";
+import bilVaultAbi from "../src/resources/bil-vault.abi.js";
+
+describe("BIL vault ABI", () => {
+  const iface = new ethers.utils.Interface(bilVaultAbi);
+
+  const roundtrip = (name, values) => {
+    const fragment = iface.getEvent(name);
+    const {data, topics} = iface.encodeEventLog(fragment, values);
+    return iface.parseLog({data, topics});
+  };
+
+  it("decodes Deposited", () => {
+    const user = "0x" + "11".repeat(20);
+    const {name, args} = roundtrip("Deposited", [user, 1000, 900, 7]);
+    expect(name).toBe("Deposited");
+    expect(args.user.toLowerCase()).toBe(user);
+    expect(args.hollarAmount.toNumber()).toBe(1000);
+    expect(args.bilMinted.toNumber()).toBe(900);
+    expect(args.tokenId.toNumber()).toBe(7);
+  });
+
+  it("decodes RedemptionRequested", () => {
+    const user = "0x" + "22".repeat(20);
+    const {args} = roundtrip("RedemptionRequested", [3, user, 500]);
+    expect(args.requestId.toNumber()).toBe(3);
+    expect(args.user.toLowerCase()).toBe(user);
+    expect(args.bilAmount.toNumber()).toBe(500);
+  });
+
+  it("decodes RedemptionFulfilled", () => {
+    const user = "0x" + "33".repeat(20);
+    const {args} = roundtrip("RedemptionFulfilled", [4, user, 480, 500]);
+    expect(args.requestId.toNumber()).toBe(4);
+    expect(args.hollarAmount.toNumber()).toBe(480);
+    expect(args.bilBurned.toNumber()).toBe(500);
+  });
+
+  it("decodes RedemptionCancelled", () => {
+    const {args} = roundtrip("RedemptionCancelled", [5, 250]);
+    expect(args.requestId.toNumber()).toBe(5);
+    expect(args.bilReturned.toNumber()).toBe(250);
+  });
+
+  it("decodes Withdraw", () => {
+    const [a, b, c] = ["0x" + "44".repeat(20), "0x" + "55".repeat(20), "0x" + "66".repeat(20)];
+    const {args} = roundtrip("Withdraw", [a, b, c, 700, 650]);
+    expect(args.receiver.toLowerCase()).toBe(b);
+    expect(args.assets.toNumber()).toBe(700);
+    expect(args.shares.toNumber()).toBe(650);
+  });
+});


### PR DESCRIPTION
Adds an opt-in BIL activity feed to Discord, mirroring the existing borrowing/stableswap handlers.

- New `src/handlers/bil.js` (+ `src/resources/bil-vault.abi.js`), gated behind `ALERT_BIL` (default off, documented in `ALERTS.md`) → when disabled the handler registers nothing, zero overhead.
- Vault lifecycle (ERC-4626/7540 vault `0x6a21891Db0940491603f3ccA0a9f4DBA4c6E810C`): reports `Deposited`, `RedemptionRequested`, `RedemptionFulfilled`/`RedemptionPartiallyFulfilled`, `RedemptionCancelled`, and settled `Withdraw` claims. EVM logs are address-filtered to the vault so generic event names (`Withdraw`) can't cross-fire.
- Amounts resolved via `loadCurrency` → HOLLAR shown as asset 222, share amounts as uBIL (asset 550); the canonical duplicate events (`Deposit`/`RedeemRequest`) are skipped so each action posts once.
- 2-Pool-BIL swaps (stableswap pool `10055`, BIL=55 / HOLLAR=222): reported via the shared `swapHandler`. To avoid double-posting, the generic stableswap handler now carves these out with `!isBilSwap(e)` — same pattern as the existing `!isHsm(e)` carve-out — and only while the feed is enabled, so default behaviour is unchanged.
- Test: `tests/bil.test.js` round-trips every vault event through the ABI to lock the fragments to the Solidity definitions. `npm test -- tests/bil.test.js` → 5 passing.