### PR TITLE
feat: contract intel on deployment alerts

### DIFF
--- a/ALERTS.md
+++ b/ALERTS.md
@@ -97,7 +97,7 @@ one line per fact that could be established (missing probes degrade the alert, n
 - **token probe**: `name()` / `symbol()` / `decimals()` / `totalSupply()` and `owner()`
   via `eth_call` (works through proxies)
 - **deployer**: transaction count and whether the EVM address is bound to a substrate account
-- **origin**: top-level deploy vs `via factory` (with the factory classified too) + tx hash
+- **origin**: top-level deploy vs `via` the transaction target (classified too) + tx hash
 
 ### BIL Vault + 2-Pool-BIL Feed
 **Type:** always on (no configuration)

--- a/ALERTS.md
+++ b/ALERTS.md
@@ -75,7 +75,8 @@ ALERT_DEPLOYMENT=true
 ```
 
 **Alert Behavior:**
-- **🚨 TRIGGERED**: Fires once per deployed contract with its address and block number
+- **🚨 TRIGGERED**: Fires once per deployed contract with its address, block number and
+  an intel report on the fresh contract
 - No resolution state — each deployment is a standalone notification
 
 **Detection:** Rather than relying on `evm.Created` (which Frontier only emits for top-level
@@ -84,6 +85,19 @@ bytecode went from empty to non-empty in that block. This catches factory / CREA
 deployments too. At init it preseeds the set of already-deployed contracts (from
 `evm.accountCodes`) so calls to existing contracts are skipped without a chain read. When the
 alert is disabled the handler is not registered at all — zero overhead.
+
+**Contract intel:** Each alert enriches the bare address with static and live analysis,
+one line per fact that could be established (missing probes degrade the alert, never block it):
+- **bytecode**: size, dispatcher selectors mapped to well-known function names, and a
+  fingerprint classification (ERC20 / ERC721 / ERC1155 / ERC4626 vault / UUPS / EIP-1167
+  minimal proxy). The opcode walk skips PUSH immediates and strips CBOR metadata, so data
+  bytes don't count as instructions.
+- **risky opcodes**: ⚠️ flags `selfdestruct`, `delegatecall`, `create`, `create2`
+- **proxy resolution**: EIP-1967 implementation / admin / beacon slots, EIP-1167 clone target
+- **token probe**: `name()` / `symbol()` / `decimals()` / `totalSupply()` and `owner()`
+  via `eth_call` (works through proxies)
+- **deployer**: transaction count and whether the EVM address is bound to a substrate account
+- **origin**: top-level deploy vs `via factory` (with the factory classified too) + tx hash
 
 ### BIL Vault + 2-Pool-BIL Feed
 **Type:** always on (no configuration)
@@ -151,7 +165,13 @@ ALERT_PRICE_DELTA='[
 
 ### Contract Deployment Alerts
 ```
-🚨 **ALERT TRIGGERED** - New contract deployed at 0x1234...abcd in block #4776718
+🚨 **ALERT TRIGGERED** - New contract deployed at `0x6a21891db0940491603f3cca0a9f4dba4c6e810c` in block #12860846
+├ EIP-1967 proxy — 209 B
+├ token "Brazilian Invoice Loans" (BIL, 18 dec, supply 0)
+├ impl `0x804d2Fd6951d60510BBF6Fe2fE9F90829aB06BDa`
+├ deployer `0x71feb8b2849101a6e62e3369eaafdc6154cd0bc0` — 395 txs, unbound
+├ top-level deploy
+└ tx `0xfa91c9295f7700610e4c346541b5232a8011f9b758c0dba90c3c4d738698e65e`
 ```
 
 ## Monitoring & Management

--- a/src/handlers/bil.js
+++ b/src/handlers/bil.js
@@ -1,4 +1,4 @@
-import {formatAccount, formatAsset, loadCurrency} from "../currencies.js";
+import {formatAccount, formatAmount, formatAsset, loadCurrency} from "../currencies.js";
 import {broadcast} from "../discord.js";
 import {swapHandler} from "./xyk.js";
 import {toAccount} from "../utils/evm.js";
@@ -11,9 +11,10 @@ export const VAULT_ADDRESS = '0x6a21891db0940491603f3cca0a9f4dba4c6e810c';
 export const BIL_POOL_ID = 10055;
 
 // Hydration asset ids the feed formats amounts as. HOLLAR is the vault
-// underlying; uBIL (550) is the vault share the events count in.
+// underlying; vault-share amounts are emitted in uBIL (550) units but shown as
+// BIL (asset 55, the 1:1 aToken) so users see "BIL".
 const HOLLAR = 222;
-const UBIL = 550;
+const BIL = 55;
 
 // Hands 2-Pool-BIL swaps from the generic stableswap handler to this feed
 // without double-posting — mirrors the isHsm carve-out.
@@ -24,12 +25,15 @@ export function isBilSwap({event}) {
 const atVault = ({event: {data: {log}}}) => log.address.toString().toLowerCase() === VAULT_ADDRESS;
 
 const hollar = amount => ({currencyId: HOLLAR, amount});
-const ubil = amount => ({currencyId: UBIL, amount});
+const bil = amount => ({currencyId: BIL, amount});
+// HOLLAR is the value unit, so render it bold with no redundant conversion
+// tilde. BIL keeps formatAsset's tilde (its HOLLAR value is informative).
+const fmtHollar = amount => `**${formatAmount(hollar(amount))}**`;
 
 export default function bilHandler(events) {
   // Pull the vault underlying + share into the currency cache; they only move
   // via evm.Log so currenciesHandler never sees them.
-  Promise.all([HOLLAR, UBIL].map(loadCurrency)).catch(() => {});
+  Promise.all([HOLLAR, BIL].map(loadCurrency)).catch(() => {});
 
   events
     .onLog('Deposited', bilVaultAbi, deposited, atVault)
@@ -43,16 +47,16 @@ export default function bilHandler(events) {
 }
 
 async function deposited({log: {args: {user, hollarAmount, bilMinted}}}) {
-  await Promise.all([HOLLAR, UBIL].map(loadCurrency));
+  await Promise.all([HOLLAR, BIL].map(loadCurrency));
   const account = await toAccount(user);
-  const message = `🇧🇷 ${formatAccount(account)} deposited ${await formatAsset(hollar(hollarAmount))} into the BIL vault for ${await formatAsset(ubil(bilMinted))}`;
+  const message = `${formatAccount(account)} deposited ${fmtHollar(hollarAmount)} into the 🇧🇷 BIL vault for ${await formatAsset(bil(bilMinted))}`;
   broadcast(message);
 }
 
 async function redemptionRequested({log: {args: {requestId, user, bilAmount}}}) {
-  await loadCurrency(UBIL);
+  await loadCurrency(BIL);
   const account = await toAccount(user);
-  const message = `🇧🇷 ${formatAccount(account)} requested BIL redemption #${requestId.toString()} of ${await formatAsset(ubil(bilAmount))}`;
+  const message = `${formatAccount(account)} requested 🇧🇷 BIL redemption #${requestId.toString()} of ${await formatAsset(bil(bilAmount))}`;
   broadcast(message);
 }
 
@@ -65,22 +69,22 @@ async function redemptionPartiallyFulfilled({log: {args}}) {
 }
 
 async function settled({requestId, user, hollarAmount, bilBurned}, verb) {
-  await Promise.all([HOLLAR, UBIL].map(loadCurrency));
+  await Promise.all([HOLLAR, BIL].map(loadCurrency));
   const account = await toAccount(user);
-  const message = `🇧🇷 BIL redemption #${requestId.toString()} ${verb} for ${formatAccount(account)}: ${await formatAsset(ubil(bilBurned))} → ${await formatAsset(hollar(hollarAmount))}`;
+  const message = `🇧🇷 BIL redemption #${requestId.toString()} ${verb} for ${formatAccount(account)}: ${await formatAsset(bil(bilBurned))} → ${fmtHollar(hollarAmount)}`;
   broadcast(message);
 }
 
 async function redemptionCancelled({log: {args: {requestId, bilReturned}}}) {
-  await loadCurrency(UBIL);
-  const message = `🇧🇷 BIL redemption #${requestId.toString()} cancelled, ${await formatAsset(ubil(bilReturned))} returned`;
+  await loadCurrency(BIL);
+  const message = `🇧🇷 BIL redemption #${requestId.toString()} cancelled, ${await formatAsset(bil(bilReturned))} returned`;
   broadcast(message);
 }
 
 async function withdraw({log: {args: {receiver, assets, shares}}}) {
-  await Promise.all([HOLLAR, UBIL].map(loadCurrency));
+  await Promise.all([HOLLAR, BIL].map(loadCurrency));
   const account = await toAccount(receiver);
-  const message = `🇧🇷 ${formatAccount(account)} claimed ${await formatAsset(hollar(assets))} from the BIL vault, burning ${await formatAsset(ubil(shares))}`;
+  const message = `${formatAccount(account)} claimed ${fmtHollar(assets)} from the 🇧🇷 BIL vault, burning ${await formatAsset(bil(shares))}`;
   broadcast(message);
 }
 

--- a/src/handlers/deployments.js
+++ b/src/handlers/deployments.js
@@ -1,6 +1,6 @@
 import {api} from "../api.js";
 import {getAlerts} from "../utils/alerts.js";
-import {analyzeBytecode, probeContract, probeDeployer} from "../utils/contractIntel.js";
+import {analyzeBytecode, attempt, probeContract, probeDeployer} from "../utils/contractIntel.js";
 
 // Addresses already holding bytecode, so normal calls to them are skipped without a chain
 // read. Seeded once at init from evm.accountCodes and extended as new deploys are seen.
@@ -71,12 +71,8 @@ async function gatherIntel(address, codeHex, deployer, target) {
 }
 
 async function analyzeKnownFactory(factory) {
-  try {
-    const code = await api().query.evm.accountCodes(factory);
-    return analyzeBytecode(code.toHex()).kind;
-  } catch {
-    return null;
-  }
+  const code = await attempt(() => api().query.evm.accountCodes(factory));
+  return code ? analyzeBytecode(code.toHex()).kind : null;
 }
 
 // EVM addresses touched by this transaction that could be freshly deployed contracts:

--- a/src/handlers/deployments.js
+++ b/src/handlers/deployments.js
@@ -1,5 +1,6 @@
 import {api} from "../api.js";
 import {getAlerts} from "../utils/alerts.js";
+import {analyzeBytecode, probeContract, probeDeployer} from "../utils/contractIntel.js";
 
 // Addresses already holding bytecode, so normal calls to them are skipped without a chain
 // read. Seeded once at init from evm.accountCodes and extended as new deploys are seen.
@@ -26,6 +27,11 @@ async function executedHandler({event, siblings, blockNumber, blockHash}) {
   const candidates = candidateAddresses(event, siblings);
   if (!candidates.size) return;
 
+  const {data} = event;
+  const deployer = data.from?.toString().toLowerCase();
+  const target = data.to?.toString().toLowerCase();
+  const txHash = data.transactionHash?.toString();
+
   let parentHash;
   for (const address of candidates) {
     if (knownContracts.has(address)) continue; // deployed before — not news
@@ -39,8 +45,37 @@ async function executedHandler({event, siblings, blockNumber, blockHash}) {
 
     knownContracts.add(address); // remember so we never re-check it
     if (before.toHex() === '0x') {
-      await getAlerts().checkDeployment(address, blockNumber);
+      const intel = await gatherIntel(address, after.toHex(), deployer, target);
+      await getAlerts().checkDeployment(address, blockNumber, {deployer, txHash, ...intel});
     }
+  }
+}
+
+// enrichment is strictly best-effort: whatever fails, the bare alert still goes out
+async function gatherIntel(address, codeHex, deployer, target) {
+  try {
+    const code = analyzeBytecode(codeHex);
+    // a candidate that isn't the call target was spawned by an inner CREATE/CREATE2 —
+    // the transaction target is the factory
+    const factory = target && target !== address ? target : null;
+    const [probe, deployerIntel, factoryKnown] = await Promise.all([
+      probeContract(address),
+      deployer ? probeDeployer(deployer) : null,
+      factory ? analyzeKnownFactory(factory) : null,
+    ]);
+    return {code, probe, deployerIntel, factory, factoryKind: factoryKnown};
+  } catch (e) {
+    console.error('deployment alert: intel gathering failed for', address, e);
+    return {};
+  }
+}
+
+async function analyzeKnownFactory(factory) {
+  try {
+    const code = await api().query.evm.accountCodes(factory);
+    return analyzeBytecode(code.toHex()).kind;
+  } catch {
+    return null;
   }
 }
 

--- a/src/utils/alerts.js
+++ b/src/utils/alerts.js
@@ -268,13 +268,48 @@ class Alerts {
     return this.alertConfigs.deployment;
   }
 
-  async checkDeployment(address, blockNumber) {
+  async checkDeployment(address, blockNumber, intel = {}) {
     if (!this.alertConfigs.deployment) return;
 
-    const message = `New contract deployed at ${address}${blockNumber ? ` in block #${blockNumber}` : ''}`;
+    const message = [
+      `New contract deployed at \`${address}\`${blockNumber ? ` in block #${blockNumber}` : ''}`,
+      ...this.describeDeployment(intel).map((line, i, lines) =>
+        `${i === lines.length - 1 ? '└' : '├'} ${line}`),
+    ].join('\n');
 
     // fire-and-forget notification: every deployment notifies, no active state to resolve
     await this.triggerAlert('deployment', address, 'BAD', message, false);
+  }
+
+  // one line per known fact, all optional — bare alert if enrichment came up empty
+  describeDeployment({code, probe = {}, deployerIntel, deployer, factory, factoryKind, txHash}) {
+    const lines = [];
+    const num = n => new Intl.NumberFormat('en-US').format(n).replace(/,/g, ' ');
+
+    if (code?.size) {
+      const kind = probe.proxy ? `${probe.proxy} proxy` : code.kind || 'contract';
+      const fns = code.minimalProxyImpl ? ''
+        : code.names.length ? `, fns: ${code.names.slice(0, 8).join(', ')}${code.selectors.length > code.names.length ? ` +${code.selectors.length - code.names.length} more` : ''}`
+        : code.selectors.length ? `, ${code.selectors.length} fns` : '';
+      lines.push(`${kind} — ${num(code.size)} B${fns}`);
+    }
+    if (probe.name || probe.symbol) {
+      const details = [probe.symbol, probe.decimals != null && `${probe.decimals} dec`,
+        probe.supply != null && `supply ${num(probe.supply)}`].filter(Boolean).join(', ');
+      lines.push(`token "${probe.name || probe.symbol}" (${details})`);
+    }
+    const impl = code?.minimalProxyImpl || probe.impl;
+    if (impl) lines.push(`impl \`${impl}\`${probe.admin ? ` admin \`${probe.admin}\`` : ''}${probe.beacon ? ` beacon \`${probe.beacon}\`` : ''}`);
+    if (probe.owner) lines.push(`owner \`${probe.owner}\``);
+    if (deployer) {
+      const activity = deployerIntel?.txCount != null ? `${num(deployerIntel.txCount)} txs` : null;
+      const binding = deployerIntel ? (deployerIntel.bound ? 'bound substrate account' : 'unbound') : null;
+      lines.push(`deployer \`${deployer}\`${activity || binding ? ` — ${[activity, binding].filter(Boolean).join(', ')}` : ''}`);
+    }
+    lines.push(factory ? `via factory \`${factory}\`${factoryKind ? ` (${factoryKind})` : ''}` : 'top-level deploy');
+    if (code?.flags?.length) lines.push(`⚠️ opcodes: ${code.flags.join(', ')}`);
+    if (txHash) lines.push(`tx \`${txHash}\``);
+    return lines;
   }
 
   getPricePairs() {

--- a/src/utils/alerts.js
+++ b/src/utils/alerts.js
@@ -284,29 +284,43 @@ class Alerts {
   // one line per known fact, all optional — bare alert if enrichment came up empty
   describeDeployment({code, probe = {}, deployerIntel, deployer, factory, factoryKind, txHash}) {
     const lines = [];
-    const num = n => new Intl.NumberFormat('en-US').format(n).replace(/,/g, ' ');
+    const group = s => String(s).replace(/\B(?=(\d{3})+(?!\d))/g, ' ');
+    // exact decimal string in, readable amount out — no float roundtrip
+    const supply = s => {
+      const [int, frac = ''] = String(s).split('.');
+      if (int !== '0') return group(int);
+      const sig = frac.replace(/0+$/, '');
+      return sig ? `0.${sig}` : '0';
+    };
 
     if (code?.size) {
       const kind = probe.proxy ? `${probe.proxy} proxy` : code.kind || 'contract';
+      const shown = [...new Set(code.names)].slice(0, 8);
+      const hidden = code.selectors.length - shown.length;
       const fns = code.minimalProxyImpl ? ''
-        : code.names.length ? `, fns: ${code.names.slice(0, 8).join(', ')}${code.selectors.length > code.names.length ? ` +${code.selectors.length - code.names.length} more` : ''}`
+        : shown.length ? `, fns: ${shown.join(', ')}${hidden > 0 ? ` +${hidden} more` : ''}`
         : code.selectors.length ? `, ${code.selectors.length} fns` : '';
-      lines.push(`${kind} — ${num(code.size)} B${fns}`);
+      lines.push(`${kind} — ${group(code.size)} B${fns}`);
     }
     if (probe.name || probe.symbol) {
       const details = [probe.symbol, probe.decimals != null && `${probe.decimals} dec`,
-        probe.supply != null && `supply ${num(probe.supply)}`].filter(Boolean).join(', ');
+        probe.supply != null && `supply ${supply(probe.supply)}`].filter(Boolean).join(', ');
       lines.push(`token "${probe.name || probe.symbol}" (${details})`);
     }
     const impl = code?.minimalProxyImpl || probe.impl;
-    if (impl) lines.push(`impl \`${impl}\`${probe.admin ? ` admin \`${probe.admin}\`` : ''}${probe.beacon ? ` beacon \`${probe.beacon}\`` : ''}`);
+    if (impl || probe.beacon) {
+      lines.push([impl && `impl \`${impl}\``, probe.admin && `admin \`${probe.admin}\``,
+        probe.beacon && `beacon \`${probe.beacon}\``].filter(Boolean).join(' '));
+    }
     if (probe.owner) lines.push(`owner \`${probe.owner}\``);
     if (deployer) {
-      const activity = deployerIntel?.txCount != null ? `${num(deployerIntel.txCount)} txs` : null;
-      const binding = deployerIntel ? (deployerIntel.bound ? 'bound substrate account' : 'unbound') : null;
+      const activity = deployerIntel?.txCount != null ? `${group(deployerIntel.txCount)} txs` : null;
+      // bound is tri-state: null means the probe failed, so say nothing rather than "unbound"
+      const binding = deployerIntel?.bound === true ? 'bound substrate account'
+        : deployerIntel?.bound === false ? 'unbound' : null;
       lines.push(`deployer \`${deployer}\`${activity || binding ? ` — ${[activity, binding].filter(Boolean).join(', ')}` : ''}`);
     }
-    lines.push(factory ? `via factory \`${factory}\`${factoryKind ? ` (${factoryKind})` : ''}` : 'top-level deploy');
+    lines.push(factory ? `via \`${factory}\`${factoryKind ? ` (${factoryKind})` : ''}` : 'top-level deploy');
     if (code?.flags?.length) lines.push(`⚠️ opcodes: ${code.flags.join(', ')}`);
     if (txHash) lines.push(`tx \`${txHash}\``);
     return lines;

--- a/src/utils/contractIntel.js
+++ b/src/utils/contractIntel.js
@@ -43,7 +43,7 @@ const SELECTOR_NAMES = {
   '0x128acb08': 'swap',
   '0xac9650d8': 'multicall',
   '0x1cff79cd': 'execute',
-  '0x522f6815': 'flashLoan',
+  '0x5cffe9de': 'flashLoan',
   '0xab9c4b5d': 'flashLoan',
 };
 
@@ -61,14 +61,22 @@ const ERC20_ABI = [
 ];
 
 // resolve to null instead of hanging/rejecting so a wedged rpc can't stall the alert
-const attempt = (fn, ms = 4000) => Promise.race([
+export const attempt = (fn, ms = 4000) => Promise.race([
   Promise.resolve().then(fn).catch(() => null),
   new Promise(resolve => setTimeout(() => resolve(null), ms).unref?.()),
 ]);
 
-// solidity appends cbor metadata (…"solc"…) with a 2-byte length suffix; strip it so the
-// opcode walk doesn't misread hash bytes as SELFDESTRUCT & co.
+// solidity appends cbor metadata (…"solc"…) with a 2-byte length suffix — and embeds the
+// same block mid-buffer for every sub-assembly (child creation code of `new Child()`).
+// cut at the earliest byte-aligned marker so random hash bytes never decode as opcodes;
+// fall back to the trailing-length heuristic for exotic layouts.
 export function stripMetadata(code) {
+  const hex = code.toString('hex');
+  const marker = /a264697066735822|a165627a7a723058|a265627a7a72315820/g;
+  for (let m; (m = marker.exec(hex));) {
+    if (m.index % 2 === 0) return code.subarray(0, m.index / 2);
+    marker.lastIndex = m.index + 1;
+  }
   if (code.length < 4) return code;
   const len = (code[code.length - 2] << 8) | code[code.length - 1];
   const start = code.length - 2 - len;
@@ -83,7 +91,8 @@ export function analyzeBytecode(codeHex) {
   const intel = {size: hex.length / 2, selectors: [], names: [], flags: [], minimalProxyImpl: null, kind: null};
   if (!hex.length) return intel;
 
-  const clone = hex.match(/^363d3d373d3d3d363d73([0-9a-f]{40})5af43d82803e903d91602b57fd5bf3$/);
+  const clone = hex.match(/^363d3d373d3d3d363d73([0-9a-f]{40})5af43d82803e903d91602b57fd5bf3$/)
+    || hex.match(/^3d3d3d3d363d3d37363d73([0-9a-f]{40})5af43d3d93803e602a57fd5bf3$/); // solady
   if (clone) {
     intel.minimalProxyImpl = '0x' + clone[1];
     intel.kind = 'EIP-1167 minimal proxy';
@@ -93,12 +102,17 @@ export function analyzeBytecode(codeHex) {
   const code = stripMetadata(Buffer.from(hex, 'hex'));
   const selectors = new Set();
   const flags = new Set();
+  let lastCompare = -1;
   for (let i = 0; i < code.length; i++) {
     const op = code[i];
     if (op >= 0x60 && op <= 0x7f) { // PUSHn — skip immediate
       const n = op - 0x5f;
-      if (op === 0x63 && code[i + 5] === 0x14) { // PUSH4 <sel> EQ — dispatcher compare
+      // PUSH4 <sel> followed by EQ / SUB / XOR — dispatcher compare (legacy and via-ir).
+      // compares sit densely packed; a distant hit is an embedded child's dispatcher, not ours
+      if (op === 0x63 && [0x14, 0x03, 0x18].includes(code[i + 5])
+        && (lastCompare === -1 || i - lastCompare <= 256)) {
         selectors.add('0x' + code.subarray(i + 1, i + 5).toString('hex'));
+        lastCompare = i;
       }
       i += n;
     } else if (op === 0xff) flags.add('selfdestruct');
@@ -127,23 +141,28 @@ function classify(s) {
 // everything best-effort — a dead probe degrades the alert, never blocks it.
 export async function probeContract(address) {
   const probe = {};
-  const [impl, admin, beacon] = await Promise.all(
-    [IMPL_SLOT, ADMIN_SLOT, BEACON_SLOT].map(slot =>
-      attempt(() => provider.getStorageAt(address, slot).then(slotAddress))));
-  if (impl) Object.assign(probe, {impl, admin, beacon, proxy: 'EIP-1967'});
-  else if (beacon) Object.assign(probe, {beacon, proxy: 'EIP-1967 beacon'});
-
   const token = new ethers.Contract(address, ERC20_ABI, provider);
-  const [name, symbol, decimals, totalSupply, owner] = await Promise.all([
+  const [impl, admin, beacon, name, symbol, decimals, totalSupply, owner] = await Promise.all([
+    ...[IMPL_SLOT, ADMIN_SLOT, BEACON_SLOT].map(slot =>
+      attempt(() => provider.getStorageAt(address, slot).then(slotAddress))),
     attempt(() => token.name()),
     attempt(() => token.symbol()),
     attempt(() => token.decimals()),
     attempt(() => token.totalSupply()),
     attempt(() => token.owner().then(o => o === ethers.constants.AddressZero ? null : o)),
   ]);
+  if (impl) Object.assign(probe, {impl, admin, beacon, proxy: 'EIP-1967'});
+  else if (beacon) {
+    // beacon proxies keep the implementation on the beacon, not in the proxy
+    const beaconImpl = await attempt(() =>
+      new ethers.Contract(beacon, ['function implementation() view returns (address)'], provider)
+        .implementation());
+    Object.assign(probe, {impl: beaconImpl, beacon, proxy: 'EIP-1967 beacon'});
+  }
   if (name || symbol) {
+    // keep supply as the exact decimal string — Number() fabricates digits past 2^53
     const supply = totalSupply != null && decimals != null
-      ? Number(ethers.utils.formatUnits(totalSupply, decimals)) : null;
+      ? ethers.utils.formatUnits(totalSupply, decimals) : null;
     Object.assign(probe, {name: sanitizeLabel(name), symbol: sanitizeLabel(symbol), decimals, supply});
   }
   if (owner) probe.owner = owner;
@@ -171,5 +190,6 @@ export async function probeDeployer(address) {
       return !extension.isEmpty;
     }),
   ]);
-  return {address, txCount, bound: !!bound};
+  // bound stays null when the probe failed — unknown is not "unbound"
+  return {address, txCount, bound};
 }

--- a/src/utils/contractIntel.js
+++ b/src/utils/contractIntel.js
@@ -1,0 +1,175 @@
+import ethers from "ethers";
+import {api} from "../api.js";
+import {provider} from "./evm.js";
+
+// well-known 4-byte selectors, enough to fingerprint the usual suspects
+const SELECTOR_NAMES = {
+  '0xa9059cbb': 'transfer',
+  '0x23b872dd': 'transferFrom',
+  '0x095ea7b3': 'approve',
+  '0x70a08231': 'balanceOf',
+  '0x18160ddd': 'totalSupply',
+  '0x06fdde03': 'name',
+  '0x95d89b41': 'symbol',
+  '0x313ce567': 'decimals',
+  '0xdd62ed3e': 'allowance',
+  '0x40c10f19': 'mint',
+  '0x42966c68': 'burn',
+  '0x8da5cb5b': 'owner',
+  '0xf2fde38b': 'transferOwnership',
+  '0x715018a6': 'renounceOwnership',
+  '0x8456cb59': 'pause',
+  '0x3f4ba83a': 'unpause',
+  '0x3659cfe6': 'upgradeTo',
+  '0x4f1ef286': 'upgradeToAndCall',
+  '0x5c60da1b': 'implementation',
+  '0x8129fc1c': 'initialize',
+  '0xc4d66de8': 'initialize',
+  '0x01ffc9a7': 'supportsInterface',
+  '0x6352211e': 'ownerOf',
+  '0x42842e0e': 'safeTransferFrom',
+  '0xb88d4fde': 'safeTransferFrom',
+  '0xa22cb465': 'setApprovalForAll',
+  '0xf242432a': 'safeTransferFrom',
+  '0x2eb2c2d6': 'safeBatchTransferFrom',
+  '0xd0e30db0': 'deposit',
+  '0x6e553f65': 'deposit',
+  '0x2e1a7d4d': 'withdraw',
+  '0xb460af94': 'withdraw',
+  '0x38d52e0f': 'asset',
+  '0x94bf804d': 'mint',
+  '0xba087652': 'redeem',
+  '0x022c0d9f': 'swap',
+  '0x128acb08': 'swap',
+  '0xac9650d8': 'multicall',
+  '0x1cff79cd': 'execute',
+  '0x522f6815': 'flashLoan',
+  '0xab9c4b5d': 'flashLoan',
+};
+
+// eip-1967 storage slots
+const IMPL_SLOT = '0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc';
+const ADMIN_SLOT = '0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103';
+const BEACON_SLOT = '0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50';
+
+const ERC20_ABI = [
+  'function name() view returns (string)',
+  'function symbol() view returns (string)',
+  'function decimals() view returns (uint8)',
+  'function totalSupply() view returns (uint256)',
+  'function owner() view returns (address)',
+];
+
+// resolve to null instead of hanging/rejecting so a wedged rpc can't stall the alert
+const attempt = (fn, ms = 4000) => Promise.race([
+  Promise.resolve().then(fn).catch(() => null),
+  new Promise(resolve => setTimeout(() => resolve(null), ms).unref?.()),
+]);
+
+// solidity appends cbor metadata (…"solc"…) with a 2-byte length suffix; strip it so the
+// opcode walk doesn't misread hash bytes as SELFDESTRUCT & co.
+export function stripMetadata(code) {
+  if (code.length < 4) return code;
+  const len = (code[code.length - 2] << 8) | code[code.length - 1];
+  const start = code.length - 2 - len;
+  if (len > 0 && start >= 0 && (code[start] & 0xf0) === 0xa0) return code.subarray(0, start);
+  return code;
+}
+
+// static bytecode analysis: size, dispatcher selectors, risky opcodes, minimal-proxy target.
+// walks opcodes skipping PUSH immediates, so data bytes don't count as instructions.
+export function analyzeBytecode(codeHex) {
+  const hex = (codeHex || '0x').replace(/^0x/, '').toLowerCase();
+  const intel = {size: hex.length / 2, selectors: [], names: [], flags: [], minimalProxyImpl: null, kind: null};
+  if (!hex.length) return intel;
+
+  const clone = hex.match(/^363d3d373d3d3d363d73([0-9a-f]{40})5af43d82803e903d91602b57fd5bf3$/);
+  if (clone) {
+    intel.minimalProxyImpl = '0x' + clone[1];
+    intel.kind = 'EIP-1167 minimal proxy';
+    return intel;
+  }
+
+  const code = stripMetadata(Buffer.from(hex, 'hex'));
+  const selectors = new Set();
+  const flags = new Set();
+  for (let i = 0; i < code.length; i++) {
+    const op = code[i];
+    if (op >= 0x60 && op <= 0x7f) { // PUSHn — skip immediate
+      const n = op - 0x5f;
+      if (op === 0x63 && code[i + 5] === 0x14) { // PUSH4 <sel> EQ — dispatcher compare
+        selectors.add('0x' + code.subarray(i + 1, i + 5).toString('hex'));
+      }
+      i += n;
+    } else if (op === 0xff) flags.add('selfdestruct');
+    else if (op === 0xf4) flags.add('delegatecall');
+    else if (op === 0xf5) flags.add('create2');
+    else if (op === 0xf0) flags.add('create');
+  }
+  intel.selectors = [...selectors];
+  intel.names = intel.selectors.map(s => SELECTOR_NAMES[s]).filter(Boolean);
+  intel.flags = [...flags];
+  intel.kind = classify(new Set(intel.selectors));
+  return intel;
+}
+
+function classify(s) {
+  const all = (...xs) => xs.every(x => s.has(x));
+  if (all('0xf242432a', '0x2eb2c2d6')) return 'ERC1155';
+  if (all('0x6352211e', '0xa22cb465')) return 'ERC721';
+  if (all('0x6e553f65', '0xba087652', '0x38d52e0f')) return 'ERC4626 vault';
+  if (all('0xa9059cbb', '0x095ea7b3', '0x70a08231', '0x18160ddd')) return 'ERC20';
+  if (s.has('0x3659cfe6') || s.has('0x4f1ef286')) return 'upgradeable (UUPS)';
+  return null;
+}
+
+// live probes against the fresh contract: eip-1967 slots and token metadata.
+// everything best-effort — a dead probe degrades the alert, never blocks it.
+export async function probeContract(address) {
+  const probe = {};
+  const [impl, admin, beacon] = await Promise.all(
+    [IMPL_SLOT, ADMIN_SLOT, BEACON_SLOT].map(slot =>
+      attempt(() => provider.getStorageAt(address, slot).then(slotAddress))));
+  if (impl) Object.assign(probe, {impl, admin, beacon, proxy: 'EIP-1967'});
+  else if (beacon) Object.assign(probe, {beacon, proxy: 'EIP-1967 beacon'});
+
+  const token = new ethers.Contract(address, ERC20_ABI, provider);
+  const [name, symbol, decimals, totalSupply, owner] = await Promise.all([
+    attempt(() => token.name()),
+    attempt(() => token.symbol()),
+    attempt(() => token.decimals()),
+    attempt(() => token.totalSupply()),
+    attempt(() => token.owner().then(o => o === ethers.constants.AddressZero ? null : o)),
+  ]);
+  if (name || symbol) {
+    const supply = totalSupply != null && decimals != null
+      ? Number(ethers.utils.formatUnits(totalSupply, decimals)) : null;
+    Object.assign(probe, {name: sanitizeLabel(name), symbol: sanitizeLabel(symbol), decimals, supply});
+  }
+  if (owner) probe.owner = owner;
+  return probe;
+}
+
+// token names come from whoever deployed the contract — keep them from smuggling
+// markdown, mentions or walls of text into the alert channel
+export const sanitizeLabel = s => typeof s === 'string'
+  ? s.replace(/[`\n\r@]/g, '').trim().slice(0, 48) || null
+  : s;
+
+const slotAddress = word => {
+  if (!word || word === ethers.constants.HashZero) return null;
+  const address = ethers.utils.getAddress('0x' + word.slice(-40));
+  return address === ethers.constants.AddressZero ? null : address;
+};
+
+// who deployed it: on-chain activity and whether the evm address is bound to a substrate account
+export async function probeDeployer(address) {
+  const [txCount, bound] = await Promise.all([
+    attempt(() => provider.getTransactionCount(address)),
+    attempt(async () => {
+      const extension = await api().query.evmAccounts.accountExtension(address);
+      return !extension.isEmpty;
+    }),
+  ]);
+  return {address, txCount, bound: !!bound};
+}

--- a/tests/contractIntel.test.js
+++ b/tests/contractIntel.test.js
@@ -12,11 +12,31 @@ describe("bytecode analysis", () => {
     expect(intel.kind).toBe('EIP-1167 minimal proxy');
   });
 
+  it("detects the solady clone variant", () => {
+    const impl = 'c0ffee254729296a45a3885639ac7e10f9d54979';
+    const intel = analyzeBytecode(`0x3d3d3d3d363d3d37363d73${impl}5af43d3d93803e602a57fd5bf3`);
+    expect(intel.minimalProxyImpl).toBe('0x' + impl);
+    expect(intel.kind).toBe('EIP-1167 minimal proxy');
+  });
+
   it("extracts dispatcher selectors and classifies erc20", () => {
     const intel = analyzeBytecode(dispatcher(['a9059cbb', '095ea7b3', '70a08231', '18160ddd', '313ce567']));
     expect(intel.selectors).toEqual(expect.arrayContaining(['0xa9059cbb', '0x095ea7b3', '0x70a08231', '0x18160ddd']));
     expect(intel.names).toEqual(expect.arrayContaining(['transfer', 'approve', 'balanceOf', 'totalSupply', 'decimals']));
     expect(intel.kind).toBe('ERC20');
+  });
+
+  it("catches via-ir SUB/XOR dispatcher compares", () => {
+    // unoptimized via-ir compiles the last compare as PUSH4 <sel> SUB PUSH2 <dst> JUMPI
+    const intel = analyzeBytecode('0x6080604052' +
+      '8063095ea7b31461004057' + '8063a9059cbb0361000e57' + '806318160ddd1861001257' + '00');
+    expect(intel.selectors.sort()).toEqual(['0x095ea7b3', '0x18160ddd', '0xa9059cbb']);
+  });
+
+  it("ignores a distant selector cluster from embedded child code", () => {
+    const intel = analyzeBytecode('0x' + '8063a9059cbb1461004057' + '00'.repeat(300) +
+      '8063deadbeef1461004057' + '00');
+    expect(intel.selectors).toEqual(['0xa9059cbb']);
   });
 
   it("classifies erc4626 vault", () => {
@@ -41,6 +61,12 @@ describe("bytecode analysis", () => {
     expect(intel.flags).toEqual([]);
     const kept = stripMetadata(Buffer.from('608060405200ff', 'hex'));
     expect(kept.length).toBe(7); // no plausible metadata → untouched
+  });
+
+  it("cuts at embedded child metadata, not just the trailing block", () => {
+    // child cbor (ipfs marker + random hash containing 0xff/0xf4) sits mid-buffer
+    const intel = analyzeBytecode('0x608060405200' + 'a264697066735822' + 'fff4'.repeat(16) + '6080604052');
+    expect(intel.flags).toEqual([]);
   });
 
   it("survives empty and non-contract input", () => {
@@ -73,7 +99,7 @@ describe("deployment alert message", () => {
       'token "Token X" (TKX, 18 dec, supply 1 000 000)',
       `owner \`0x${'11'.repeat(20)}\``,
       `deployer \`0x${'22'.repeat(20)}\` — 42 txs, bound substrate account`,
-      `via factory \`0x${'33'.repeat(20)}\` (ERC4626 vault)`,
+      `via \`0x${'33'.repeat(20)}\` (ERC4626 vault)`,
       '⚠️ opcodes: delegatecall',
       `tx \`0x${'44'.repeat(32)}\``,
     ]);
@@ -81,5 +107,35 @@ describe("deployment alert message", () => {
 
   it("degrades to the bare minimum when enrichment is empty", () => {
     expect(getAlerts().describeDeployment({})).toEqual(['top-level deploy']);
+  });
+
+  it("renders exact supply strings without float artifacts", () => {
+    const line = supply => getAlerts().describeDeployment({
+      probe: {symbol: 'X', supply}})[0];
+    expect(line('123456789012345678901.0')).toContain('supply 123 456 789 012 345 678 901');
+    expect(line('0.000000000000000001')).toContain('supply 0.000000000000000001');
+    expect(line('0.0')).toContain('supply 0');
+  });
+
+  it("says nothing about binding when the probe failed", () => {
+    const [line] = getAlerts().describeDeployment({
+      deployer: '0xabc', deployerIntel: {txCount: null, bound: null}});
+    expect(line).toBe('deployer `0xabc`');
+  });
+
+  it("shows the beacon even when its implementation could not be resolved", () => {
+    const lines = getAlerts().describeDeployment({
+      code: {size: 200, kind: null, flags: [], selectors: [], names: [], minimalProxyImpl: null},
+      probe: {proxy: 'EIP-1967 beacon', beacon: '0x' + '55'.repeat(20), impl: null}});
+    expect(lines[0]).toBe('EIP-1967 beacon proxy — 200 B');
+    expect(lines[1]).toBe(`beacon \`0x${'55'.repeat(20)}\``);
+  });
+
+  it("counts hidden functions from what was actually shown", () => {
+    const lines = getAlerts().describeDeployment({
+      code: {size: 100, kind: null, flags: [], minimalProxyImpl: null,
+        selectors: Array.from({length: 12}, (_, i) => `0x0000000${i.toString(16)}`),
+        names: ['transfer', 'transfer', 'approve']}});
+    expect(lines[0]).toBe('contract — 100 B, fns: transfer, approve +10 more');
   });
 });

--- a/tests/contractIntel.test.js
+++ b/tests/contractIntel.test.js
@@ -1,0 +1,85 @@
+import {analyzeBytecode, stripMetadata, sanitizeLabel} from "../src/utils/contractIntel.js";
+import {getAlerts} from "../src/utils/alerts.js";
+
+const dispatcher = selectors => '0x6080604052' +
+  selectors.map(s => `8063${s}1461004057`).join('') + '00';
+
+describe("bytecode analysis", () => {
+  it("detects eip-1167 minimal proxy and its implementation", () => {
+    const impl = 'c0ffee254729296a45a3885639ac7e10f9d54979';
+    const intel = analyzeBytecode(`0x363d3d373d3d3d363d73${impl}5af43d82803e903d91602b57fd5bf3`);
+    expect(intel.minimalProxyImpl).toBe('0x' + impl);
+    expect(intel.kind).toBe('EIP-1167 minimal proxy');
+  });
+
+  it("extracts dispatcher selectors and classifies erc20", () => {
+    const intel = analyzeBytecode(dispatcher(['a9059cbb', '095ea7b3', '70a08231', '18160ddd', '313ce567']));
+    expect(intel.selectors).toEqual(expect.arrayContaining(['0xa9059cbb', '0x095ea7b3', '0x70a08231', '0x18160ddd']));
+    expect(intel.names).toEqual(expect.arrayContaining(['transfer', 'approve', 'balanceOf', 'totalSupply', 'decimals']));
+    expect(intel.kind).toBe('ERC20');
+  });
+
+  it("classifies erc4626 vault", () => {
+    const intel = analyzeBytecode(dispatcher(['6e553f65', 'ba087652', '38d52e0f', '70a08231']));
+    expect(intel.kind).toBe('ERC4626 vault');
+  });
+
+  it("flags risky opcodes", () => {
+    const intel = analyzeBytecode('0x6080604052f4f5f0ff00');
+    expect(intel.flags.sort()).toEqual(['create', 'create2', 'delegatecall', 'selfdestruct']);
+  });
+
+  it("does not misread push immediates as opcodes", () => {
+    // PUSH2 0xfff4, PUSH20 of 0xff bytes — data, not SELFDESTRUCT/DELEGATECALL
+    const intel = analyzeBytecode('0x61fff473' + 'ff'.repeat(20) + '00');
+    expect(intel.flags).toEqual([]);
+  });
+
+  it("strips cbor metadata so hash bytes are not flagged", () => {
+    const meta = 'a2' + 'ff'.repeat(10); // 11 bytes
+    const intel = analyzeBytecode('0x608060405200' + meta + '000b');
+    expect(intel.flags).toEqual([]);
+    const kept = stripMetadata(Buffer.from('608060405200ff', 'hex'));
+    expect(kept.length).toBe(7); // no plausible metadata → untouched
+  });
+
+  it("survives empty and non-contract input", () => {
+    expect(analyzeBytecode('0x').size).toBe(0);
+    expect(analyzeBytecode(undefined).size).toBe(0);
+  });
+
+  it("sanitizes deployer-controlled token labels", () => {
+    expect(sanitizeLabel('`@everyone`\nrug')).toBe('everyonerug');
+    expect(sanitizeLabel('x'.repeat(100)).length).toBe(48);
+    expect(sanitizeLabel('```')).toBe(null);
+    expect(sanitizeLabel(null)).toBe(null);
+  });
+});
+
+describe("deployment alert message", () => {
+  it("renders one line per known fact", () => {
+    const lines = getAlerts().describeDeployment({
+      code: {size: 3214, kind: 'ERC20', flags: ['delegatecall'], minimalProxyImpl: null,
+        selectors: ['0xa9059cbb', '0x095ea7b3', '0xdeadbeef'], names: ['transfer', 'approve']},
+      probe: {name: 'Token X', symbol: 'TKX', decimals: 18, supply: 1000000, owner: '0x' + '11'.repeat(20)},
+      deployer: '0x' + '22'.repeat(20),
+      deployerIntel: {txCount: 42, bound: true},
+      factory: '0x' + '33'.repeat(20),
+      factoryKind: 'ERC4626 vault',
+      txHash: '0x' + '44'.repeat(32),
+    });
+    expect(lines).toEqual([
+      'ERC20 — 3 214 B, fns: transfer, approve +1 more',
+      'token "Token X" (TKX, 18 dec, supply 1 000 000)',
+      `owner \`0x${'11'.repeat(20)}\``,
+      `deployer \`0x${'22'.repeat(20)}\` — 42 txs, bound substrate account`,
+      `via factory \`0x${'33'.repeat(20)}\` (ERC4626 vault)`,
+      '⚠️ opcodes: delegatecall',
+      `tx \`0x${'44'.repeat(32)}\``,
+    ]);
+  });
+
+  it("degrades to the bare minimum when enrichment is empty", () => {
+    expect(getAlerts().describeDeployment({})).toEqual(['top-level deploy']);
+  });
+});


### PR DESCRIPTION
Enriches the contract-deployment alert with static + live analysis of the fresh contract — one line per established fact, bare alert if everything fails.

- bytecode analysis → size, dispatcher selectors mapped to known names, classification (ERC20/721/1155/4626 vault, UUPS, EIP-1167 clone)
- ⚠️ risky-opcode flags (`selfdestruct`, `delegatecall`, `create`/`create2`) → opcode walk skips PUSH immediates + strips CBOR metadata, so data bytes don't false-positive
- live probes, best-effort with 4s cap → EIP-1967 impl/admin/beacon slots, `name`/`symbol`/`decimals`/`totalSupply`, `owner()`; a dead probe degrades the alert, never blocks it
- deployer dossier → tx count + substrate-account binding; top-level vs via-factory attribution (factory classified too) + tx hash
- probed token labels sanitized → deployer-controlled strings can't smuggle mentions/markdown into the channel

Validated live against the block 12860846 deploy and the BIL vault proxy:

```
New contract deployed at `0x6a21891db0940491603f3cca0a9f4dba4c6e810c` in block #12860846
├ EIP-1967 proxy — 209 B
├ token "Brazilian Invoice Loans" (BIL, 18 dec, supply 0)
├ impl `0x804d2Fd6951d60510BBF6Fe2fE9F90829aB06BDa`
├ deployer `0x71feb8b2849101a6e62e3369eaafdc6154cd0bc0` — 395 txs, unbound
├ top-level deploy
└ tx `0xfa91c9295f7700610e4c346541b5232a8011f9b758c0dba90c3c4d738698e65e`
```