### PR TITLE
bil feed: BIL naming, no redundant HOLLAR conversion, flag placement

### DIFF
--- a/ALERTS.md
+++ b/ALERTS.md
@@ -93,9 +93,10 @@ alert is disabled the handler is not registered at all — zero overhead.
 **What it reports:**
 - **Vault lifecycle** (ERC-4626 / ERC-7540 vault at `0x6a21891Db0940491603f3ccA0a9f4DBA4c6E810C`):
   deposits, redemption requests, redemptions fulfilled / partially filled, cancellations, and
-  settled claims. HOLLAR amounts are shown as HOLLAR (asset 222); share amounts as uBIL (asset 550).
+  settled claims. HOLLAR amounts are shown as HOLLAR (asset 222); share amounts as BIL (asset 55).
 - **2-Pool-BIL swaps** (stableswap pool `10055`, assets BIL=55 / HOLLAR=222). These swaps are
   reported by the BIL feed and skipped by the generic stableswap handler so they post exactly once.
+- **BIL money-market borrows** are handled by the generic Aave feed and marked with 🇧🇷.
 
 **Behavior:** Discord broadcast only (like the borrowing / stableswap feeds), not the Slack alert
 subsystem. Always registered — no toggle.

--- a/src/handlers/bil.js
+++ b/src/handlers/bil.js
@@ -1,4 +1,4 @@
-import {formatAccount, formatAsset, loadCurrency} from "../currencies.js";
+import {formatAccount, formatAmount, formatAsset, loadCurrency} from "../currencies.js";
 import {broadcast} from "../discord.js";
 import {swapHandler} from "./xyk.js";
 import {toAccount} from "../utils/evm.js";
@@ -11,9 +11,10 @@ export const VAULT_ADDRESS = '0x6a21891db0940491603f3cca0a9f4dba4c6e810c';
 export const BIL_POOL_ID = 10055;
 
 // Hydration asset ids the feed formats amounts as. HOLLAR is the vault
-// underlying; uBIL (550) is the vault share the events count in.
+// underlying; vault-share amounts are emitted in uBIL (550) units but shown as
+// BIL (asset 55, the 1:1 aToken) so users see "BIL".
 const HOLLAR = 222;
-const UBIL = 550;
+const BIL = 55;
 
 // Hands 2-Pool-BIL swaps from the generic stableswap handler to this feed
 // without double-posting — mirrors the isHsm carve-out.
@@ -24,12 +25,15 @@ export function isBilSwap({event}) {
 const atVault = ({event: {data: {log}}}) => log.address.toString().toLowerCase() === VAULT_ADDRESS;
 
 const hollar = amount => ({currencyId: HOLLAR, amount});
-const ubil = amount => ({currencyId: UBIL, amount});
+const bil = amount => ({currencyId: BIL, amount});
+// HOLLAR is the value unit, so render it bold with no redundant conversion
+// tilde. BIL keeps formatAsset's tilde (its HOLLAR value is informative).
+const fmtHollar = amount => `**${formatAmount(hollar(amount))}**`;
 
 export default function bilHandler(events) {
   // Pull the vault underlying + share into the currency cache; they only move
   // via evm.Log so currenciesHandler never sees them.
-  Promise.all([HOLLAR, UBIL].map(loadCurrency)).catch(() => {});
+  Promise.all([HOLLAR, BIL].map(loadCurrency)).catch(() => {});
 
   events
     .onLog('Deposited', bilVaultAbi, deposited, atVault)
@@ -43,16 +47,16 @@ export default function bilHandler(events) {
 }
 
 async function deposited({log: {args: {user, hollarAmount, bilMinted}}}) {
-  await Promise.all([HOLLAR, UBIL].map(loadCurrency));
+  await Promise.all([HOLLAR, BIL].map(loadCurrency));
   const account = await toAccount(user);
-  const message = `🇧🇷 ${formatAccount(account)} deposited ${await formatAsset(hollar(hollarAmount))} into the BIL vault for ${await formatAsset(ubil(bilMinted))}`;
+  const message = `${formatAccount(account)} deposited ${fmtHollar(hollarAmount)} into the 🇧🇷 BIL vault for ${await formatAsset(bil(bilMinted))}`;
   broadcast(message);
 }
 
 async function redemptionRequested({log: {args: {requestId, user, bilAmount}}}) {
-  await loadCurrency(UBIL);
+  await loadCurrency(BIL);
   const account = await toAccount(user);
-  const message = `🇧🇷 ${formatAccount(account)} requested BIL redemption #${requestId.toString()} of ${await formatAsset(ubil(bilAmount))}`;
+  const message = `${formatAccount(account)} requested 🇧🇷 BIL redemption #${requestId.toString()} of ${await formatAsset(bil(bilAmount))}`;
   broadcast(message);
 }
 
@@ -65,22 +69,22 @@ async function redemptionPartiallyFulfilled({log: {args}}) {
 }
 
 async function settled({requestId, user, hollarAmount, bilBurned}, verb) {
-  await Promise.all([HOLLAR, UBIL].map(loadCurrency));
+  await Promise.all([HOLLAR, BIL].map(loadCurrency));
   const account = await toAccount(user);
-  const message = `🇧🇷 BIL redemption #${requestId.toString()} ${verb} for ${formatAccount(account)}: ${await formatAsset(ubil(bilBurned))} → ${await formatAsset(hollar(hollarAmount))}`;
+  const message = `🇧🇷 BIL redemption #${requestId.toString()} ${verb} for ${formatAccount(account)}: ${await formatAsset(bil(bilBurned))} → ${fmtHollar(hollarAmount)}`;
   broadcast(message);
 }
 
 async function redemptionCancelled({log: {args: {requestId, bilReturned}}}) {
-  await loadCurrency(UBIL);
-  const message = `🇧🇷 BIL redemption #${requestId.toString()} cancelled, ${await formatAsset(ubil(bilReturned))} returned`;
+  await loadCurrency(BIL);
+  const message = `🇧🇷 BIL redemption #${requestId.toString()} cancelled, ${await formatAsset(bil(bilReturned))} returned`;
   broadcast(message);
 }
 
 async function withdraw({log: {args: {receiver, assets, shares}}}) {
-  await Promise.all([HOLLAR, UBIL].map(loadCurrency));
+  await Promise.all([HOLLAR, BIL].map(loadCurrency));
   const account = await toAccount(receiver);
-  const message = `🇧🇷 ${formatAccount(account)} claimed ${await formatAsset(hollar(assets))} from the BIL vault, burning ${await formatAsset(ubil(shares))}`;
+  const message = `${formatAccount(account)} claimed ${fmtHollar(assets)} from the 🇧🇷 BIL vault, burning ${await formatAsset(bil(shares))}`;
   broadcast(message);
 }
 

--- a/src/handlers/borrowing.js
+++ b/src/handlers/borrowing.js
@@ -8,6 +8,7 @@ import Borrowers from "../utils/borrowers.js";
 import {notInRouter} from "./router.js";
 import {getAlerts} from "../utils/alerts.js";
 import ethers from "ethers";
+import {borrowMarketFlag} from "../markets.js";
 
 const borrowers = new Borrowers();
 
@@ -40,10 +41,12 @@ async function withdraw({log: {args: {reserve, amount, to}}}) {
   broadcast(message);
 }
 
-async function borrow({log: {args: {reserve, amount, onBehalfOf}}}) {
+async function borrow(payload) {
+  const {log: {args: {reserve, amount, onBehalfOf}}} = payload;
   const borrowed = {currencyId: ERC20Mapping.decodeEvmAddress(reserve), amount}
   const account = await toAccount(onBehalfOf);
-  const message = `${formatAccount(account)} borrowed ${await formatAsset(borrowed)}`;
+  const address = payload.event.data.log.address;
+  const message = `${formatAccount(account)}${borrowMarketFlag(address)} borrowed ${await formatAsset(borrowed)}`;
   broadcast(message);
 }
 

--- a/src/markets.js
+++ b/src/markets.js
@@ -1,0 +1,7 @@
+// Dedicated Aave V3 BIL money-market pool on Hydration.
+export const BIL_MONEY_MARKET_POOL_ADDRESS = '0x69310fda58c819ad82df7d2cb61841c853337a53';
+
+// Includes its own leading space for insertion after the account marker.
+export function borrowMarketFlag(address) {
+  return address.toString().toLowerCase() === BIL_MONEY_MARKET_POOL_ADDRESS ? ' 🇧🇷' : '';
+}

--- a/tests/borrowing.test.js
+++ b/tests/borrowing.test.js
@@ -1,0 +1,16 @@
+import {BIL_MONEY_MARKET_POOL_ADDRESS, borrowMarketFlag} from "../src/markets.js";
+
+describe("borrow market flag", () => {
+  it("marks the checksummed BIL pool address", () => {
+    const address = {toString: () => "0x69310FdA58c819aD82df7d2Cb61841C853337a53"};
+    expect(borrowMarketFlag(address)).toBe(" 🇧🇷");
+  });
+
+  it("marks the lowercase BIL pool address", () => {
+    expect(borrowMarketFlag(BIL_MONEY_MARKET_POOL_ADDRESS)).toBe(" 🇧🇷");
+  });
+
+  it("does not mark another money-market pool", () => {
+    expect(borrowMarketFlag("0x" + "77".repeat(20))).toBe("");
+  });
+});


### PR DESCRIPTION
Follow-up to #49 (feed review):
- **uBIL → BIL** — vault-share amounts now display as BIL (asset 55, the 1:1 aToken) instead of uBIL (550).
- **No redundant conversion** — HOLLAR amounts render as a plain bold amount (no `~` tilde, since they're already the value unit). BIL keeps its value tilde.
- **Flag placement** — 🇧🇷 no longer leads messages that already start with the account emoji; it now sits right before "BIL vault" / "BIL redemption".