### PR TITLE
feat: monitor Wormhole NTT activity

### DIFF
--- a/ALERTS.md
+++ b/ALERTS.md
@@ -115,6 +115,32 @@ one line per fact that could be established (missing probes degrade the alert, n
 **Behavior:** Discord broadcast only (like the borrowing / stableswap feeds), not the Slack alert
 subsystem. Always registered — no toggle.
 
+### Wormhole NTT Feed + Alerts
+**Type:** always on (no configuration)
+**Purpose:** Monitor the eleven production Wormhole NTT pairs that connect Hydration to
+Ethereum, Base, Solana and Sui.
+
+**Discord feed:**
+- successful outbound transfers, with asset, amount, destination chain/recipient and sequence
+- successful inbound redemptions, paired with the matching `currencies.Deposited` event so the
+  recipient and amount are shown
+- outbound queue cancellations and returned funds
+
+**Webhook alerts:**
+- any inbound or outbound NTT queue event on Hydration (the deployed Hydration limits are
+  effectively unlimited, so queueing indicates configuration drift)
+- failed NTT executions caused by the runtime mint fuse (`MintLimitReached`) or an invalid/cleared
+  runtime minter binding (`CallerNotMinter`); mint-fuse alerts call out that the VAA must be retried
+- manager/transceiver pause, ownership, pauser, implementation, peer, threshold, transceiver or
+  rate-limit changes
+- runtime NTT minter bindings being set or cleared, including an explicit warning when a binding
+  points at a manager other than the audited deployment
+- a `TransferRedeemed` event without its expected Hydration deposit
+
+The contract list is pinned to the audited production deployment instead of discovered from the
+live minter map. This keeps emergency-cleared managers under observation. Prometheus exposes
+`ntt_transfers_total` and `ntt_control_changes_total` with asset and lifecycle labels.
+
 ## Complete Configuration Example
 
 ```bash

--- a/src/bot.js
+++ b/src/bot.js
@@ -16,6 +16,7 @@ import hsm, {submitReport} from "./handlers/hsm.js";
 import circuitbreaker from "./handlers/circuitbreaker.js";
 import deployments from "./handlers/deployments.js";
 import bil from "./handlers/bil.js";
+import ntt from "./handlers/ntt.js";
 import {initDiscord} from "./discord.js";
 import "./health.js";
 import {rpc, sha, token, channel} from "./config.js";
@@ -63,6 +64,7 @@ async function main() {
   events.addHandler(circuitbreaker);
   events.addHandler(deployments);
   events.addHandler(bil);
+  events.addHandler(ntt);
 
   if (process.env.NODE_ENV === 'test') {
     console.log('testing mode: pushing testing blocks');
@@ -102,5 +104,4 @@ function exit(code = 0) {
   submitReport();
   setTimeout(() => process.exit(code), 500);
 }
-
 

--- a/src/handlers/ntt.js
+++ b/src/handlers/ntt.js
@@ -1,0 +1,252 @@
+import {broadcast} from "../discord.js";
+import {formatAccount, formatAmount, formatAsset, loadCurrency} from "../currencies.js";
+import {getAlerts} from "../utils/alerts.js";
+import {metrics} from "../metrics.js";
+import {toAccount} from "../utils/evm.js";
+import {
+  NTT_DEPLOYMENTS,
+  currencySibling,
+  formatNttRecipient,
+  knownNttAsset,
+  nttContractFromPayload,
+  nttExecutionFailure,
+  wormholeChain,
+} from "../utils/ntt.js";
+import nttManagerAbi from "../resources/ntt-manager.abi.js";
+import nttTransceiverAbi from "../resources/ntt-transceiver.abi.js";
+
+const managerControlEvents = [
+  "Paused",
+  "NotPaused",
+  "OwnershipTransferred",
+  "PauserTransferred",
+  "Upgraded",
+  "PeerUpdated",
+  "ThresholdChanged",
+  "TransceiverAdded",
+  "TransceiverRemoved",
+  "OutboundTransferLimitUpdated",
+  "InboundTransferLimitUpdated",
+];
+
+const transceiverControlEvents = [
+  "Paused",
+  "NotPaused",
+  "OwnershipTransferred",
+  "PauserTransferred",
+  "Upgraded",
+  "SetWormholePeer",
+];
+
+const nttMetrics = metrics.register("ntt", {
+  transfers_total: {
+    type: "counter",
+    help: "Number of observed NTT transfer lifecycle events",
+    labels: ["asset", "direction", "peer", "status"],
+  },
+  control_changes_total: {
+    type: "counter",
+    help: "Number of observed NTT control-plane changes",
+    labels: ["asset", "component", "event"],
+  },
+});
+
+const atComponent = component => payload => nttContractFromPayload(payload)?.component === component;
+const atManager = atComponent("manager");
+const atTransceiver = atComponent("transceiver");
+
+export default function nttHandler(events) {
+  Promise.all(NTT_DEPLOYMENTS.map(({assetId}) => loadCurrency(assetId))).catch(() => {});
+
+  events
+    .onLog("TransferSent", nttManagerAbi, transferSent, payload =>
+      atManager(payload) && payload.log.args.amount !== undefined)
+    .onLog("TransferRedeemed", nttManagerAbi, transferRedeemed, atManager)
+    .onLog("OutboundTransferRateLimited", nttManagerAbi, outboundRateLimited, atManager)
+    .onLog("OutboundTransferCancelled", nttManagerAbi, outboundCancelled, atManager)
+    .onLog("InboundTransferQueued", nttManagerAbi, inboundQueued, atManager)
+    .onFilter("ethereum", "Executed", knownExecutionFailure, executionFailed)
+    .onFilter("evmAccounts", "NttMinterSet", knownRuntimeAsset, nttMinterSet)
+    .onFilter("evmAccounts", "NttMinterCleared", knownRuntimeAsset, nttMinterCleared);
+
+  for (const eventName of managerControlEvents) {
+    events.onLog(eventName, nttManagerAbi, controlChanged(eventName), atManager);
+  }
+  for (const eventName of transceiverControlEvents) {
+    events.onLog(eventName, nttTransceiverAbi, controlChanged(eventName), atTransceiver);
+  }
+}
+
+function knownExecutionFailure({event}) {
+  return !!nttExecutionFailure(event);
+}
+
+async function executionFailed({event, blockNumber}) {
+  const {deployment, code, description} = nttExecutionFailure(event);
+  const direction = deployment.component === "transceiver" ? "inbound" : "outbound";
+  const txHash = event.data.transactionHash?.toString();
+  const recovery = code === "mint_limit_reached"
+    ? "; origin funds remain locked and the VAA must be retried when mint headroom returns"
+    : "; verify or restore the runtime NTT minter binding";
+  const message = `${deployment.symbol} NTT ${direction} execution failed: ${description}${recovery}${txHash ? ` (tx \`${txHash}\`)` : ""}${blockNumber ? ` in block #${blockNumber}` : ""}`;
+
+  broadcast(`🚨 ${message}`);
+  await getAlerts().sendWebhooks(`🚨 **NTT DELIVERY FAILED** - ${message}`);
+  countTransfer(deployment, direction, wormholeChain(deployment.peerChainId), code);
+}
+
+async function transferSent(payload) {
+  const deployment = nttContractFromPayload(payload);
+  const {recipient, amount, recipientChain, msgSequence} = payload.log.args;
+  const sender = await outboundSender(payload.siblings, deployment.assetId);
+  const account = sender ? `${formatAccount(sender)} ` : "";
+
+  await loadCurrency(deployment.assetId);
+  const asset = await formatAsset({currencyId: deployment.assetId, amount});
+  const peer = wormholeChain(recipientChain);
+  const destination = formatNttRecipient(recipient, recipientChain);
+
+  broadcast(`${account}sent ${asset} from **Hydration** to **${peer}** via 🌀 NTT → \`${destination}\` (sequence ${msgSequence})`);
+  countTransfer(deployment, "outbound", peer, "sent");
+}
+
+async function transferRedeemed(payload) {
+  const deployment = nttContractFromPayload(payload);
+  const deposit = currencySibling(payload.siblings, "Deposited", deployment.assetId);
+  const peer = wormholeChain(deployment.peerChainId);
+
+  if (!deposit) {
+    await operationalAlert(
+      deployment,
+      "inbound",
+      "redeemed_without_deposit",
+      `${deployment.symbol} NTT emitted TransferRedeemed without a matching Hydration deposit (digest \`${payload.log.args.digest}\`)`,
+    );
+    return;
+  }
+
+  const {who, amount} = deposit.data;
+  await loadCurrency(deployment.assetId);
+  const asset = await formatAsset({currencyId: deployment.assetId, amount});
+
+  broadcast(`${formatAccount(who)} received ${asset} from **${peer}** on **Hydration** via 🌀 NTT`);
+  countTransfer(deployment, "inbound", peer, "redeemed");
+}
+
+async function outboundCancelled(payload) {
+  const deployment = nttContractFromPayload(payload);
+  const {recipient, amount, sequence} = payload.log.args;
+  const account = await toAccount(recipient);
+
+  await loadCurrency(deployment.assetId);
+  const asset = await formatAsset({currencyId: deployment.assetId, amount});
+  broadcast(`${formatAccount(account)} cancelled queued 🌀 NTT transfer #${sequence}; ${asset} returned on **Hydration**`);
+  countTransfer(deployment, "outbound", wormholeChain(deployment.peerChainId), "cancelled");
+}
+
+async function outboundRateLimited(payload) {
+  const deployment = nttContractFromPayload(payload);
+  const {sender, sequence, amount, currentCapacity} = payload.log.args;
+  const account = await toAccount(sender);
+  await loadCurrency(deployment.assetId);
+
+  await operationalAlert(
+    deployment,
+    "outbound",
+    "queued",
+    `${formatAccount(account)} had ${formatAmount({currencyId: deployment.assetId, amount})} queued by the Hydration NTT manager (sequence ${sequence}, capacity ${formatAmount({currencyId: deployment.assetId, amount: currentCapacity})})`,
+  );
+}
+
+async function inboundQueued(payload) {
+  const deployment = nttContractFromPayload(payload);
+  await operationalAlert(
+    deployment,
+    "inbound",
+    "queued",
+    `${deployment.symbol} NTT inbound transfer queued on Hydration (digest \`${payload.log.args.digest}\`)`,
+  );
+}
+
+async function operationalAlert(deployment, direction, status, message) {
+  broadcast(`🚨 ${message}`);
+  await getAlerts().sendWebhooks(`🚨 **NTT ALERT** - ${message}`);
+  countTransfer(deployment, direction, wormholeChain(deployment.peerChainId), status);
+}
+
+function countTransfer(deployment, direction, peer, status) {
+  nttMetrics.transfers_total.inc({asset: deployment.symbol, direction, peer, status});
+}
+
+function knownRuntimeAsset({event}) {
+  return !!knownNttAsset(event.data.assetId);
+}
+
+async function nttMinterSet({event, blockNumber}) {
+  const deployment = knownNttAsset(event.data.assetId);
+  const minter = event.data.minter.toString();
+  const mismatch = minter.toLowerCase() !== deployment.manager.toLowerCase();
+  const detail = mismatch
+    ? ` to unexpected manager \`${minter}\` (expected \`${deployment.manager}\`)`
+    : ` to \`${minter}\``;
+  await runtimeControlAlert(deployment, "NttMinterSet", `runtime minter set${detail}`, blockNumber);
+}
+
+async function nttMinterCleared({event, blockNumber}) {
+  const deployment = knownNttAsset(event.data.assetId);
+  await runtimeControlAlert(deployment, "NttMinterCleared", "runtime minter cleared (mint and burn disabled)", blockNumber);
+}
+
+async function runtimeControlAlert(deployment, eventName, description, blockNumber) {
+  const message = `${deployment.symbol} NTT ${description}${blockNumber ? ` in block #${blockNumber}` : ""}`;
+  broadcast(`⚙️ ${message}`);
+  await getAlerts().sendWebhooks(`⚠️ **NTT CONTROL CHANGE** - ${message}`);
+  nttMetrics.control_changes_total.inc({asset: deployment.symbol, component: "runtime", event: eventName});
+}
+
+function controlChanged(eventName) {
+  return async payload => {
+    const deployment = nttContractFromPayload(payload);
+    await loadCurrency(deployment.assetId);
+    const description = describeControlChange(eventName, payload.log.args, deployment);
+    const message = `${deployment.symbol} NTT ${deployment.component} ${description}${payload.blockNumber ? ` in block #${payload.blockNumber}` : ""}`;
+
+    broadcast(`⚙️ ${message}`);
+    await getAlerts().sendWebhooks(`⚠️ **NTT CONTROL CHANGE** - ${message}`);
+    nttMetrics.control_changes_total.inc({
+      asset: deployment.symbol,
+      component: deployment.component,
+      event: eventName,
+    });
+  };
+}
+
+function describeControlChange(eventName, args, deployment) {
+  switch (eventName) {
+    case "Paused": return "paused";
+    case "NotPaused": return "unpaused";
+    case "OwnershipTransferred": return `owner changed from \`${args.previousOwner}\` to \`${args.newOwner}\``;
+    case "PauserTransferred": return `pauser changed from \`${args.oldPauser}\` to \`${args.newPauser}\``;
+    case "Upgraded": return `upgraded to implementation \`${args.implementation}\``;
+    case "PeerUpdated":
+      return `peer for ${wormholeChain(args.chainId_)} changed from \`${formatNttRecipient(args.oldPeerContract, args.chainId_)}\` to \`${formatNttRecipient(args.peerContract, args.chainId_)}\` (${args.oldPeerDecimals} → ${args.peerDecimals} decimals)`;
+    case "SetWormholePeer":
+      return `peer for ${wormholeChain(args.chainId)} set to \`${formatNttRecipient(args.peerContract, args.chainId)}\``;
+    case "ThresholdChanged": return `threshold changed from ${args.oldThreshold} to ${args.threshold}`;
+    case "TransceiverAdded": return `added transceiver \`${args.transceiver}\` (count ${args.transceiversNum}, threshold ${args.threshold})`;
+    case "TransceiverRemoved": return `removed transceiver \`${args.transceiver}\` (threshold ${args.threshold})`;
+    case "OutboundTransferLimitUpdated":
+      return `outbound limit changed from ${formatAmount({currencyId: deployment.assetId, amount: args.oldLimit})} to ${formatAmount({currencyId: deployment.assetId, amount: args.newLimit})}`;
+    case "InboundTransferLimitUpdated":
+      return `inbound limit from ${wormholeChain(args.chainId)} changed from ${formatAmount({currencyId: deployment.assetId, amount: args.oldLimit})} to ${formatAmount({currencyId: deployment.assetId, amount: args.newLimit})}`;
+    default: return eventName;
+  }
+}
+
+async function outboundSender(siblings, assetId) {
+  const transfer = currencySibling(siblings, "Transferred", assetId);
+  if (transfer?.data?.from) return transfer.data.from;
+
+  const executed = siblings.find(({section, method}) => section === "ethereum" && method === "Executed");
+  return executed?.data?.from ? toAccount(executed.data.from) : null;
+}

--- a/src/handlers/transfers.js
+++ b/src/handlers/transfers.js
@@ -1,11 +1,13 @@
 import {formatAccount, formatAmount, formatUsdValue, isWhale, usdValue} from "../currencies.js";
 import {broadcast} from "../discord.js";
+import {isNttTransfer} from "../utils/ntt.js";
 
 export default function transfersHandler(events) {
   events.onFilter(
     'currencies',
     'Transferred',
-    ({siblings}) => siblings.find(({section}) => ['xyk', 'lbp', 'omnipool', 'otc'].includes(section)) === undefined,
+    payload => payload.siblings.find(({section}) => ['xyk', 'lbp', 'omnipool', 'otc'].includes(section)) === undefined
+      && !isNttTransfer(payload),
     transferredHandler
   );
   events.onFilter(

--- a/src/resources/ntt-manager.abi.js
+++ b/src/resources/ntt-manager.abi.js
@@ -1,0 +1,21 @@
+// Minimal Wormhole NTT v2 manager ABI. Keep this event-only: Snakewatch does
+// not call the contracts and only needs enough surface to decode Hydration logs.
+export default [
+  "event TransferSent(bytes32 indexed recipient, bytes32 indexed refundAddress, uint256 amount, uint256 fee, uint16 recipientChain, uint64 msgSequence)",
+  "event TransferSent(bytes32 indexed digest)",
+  "event TransferRedeemed(bytes32 indexed digest)",
+  "event OutboundTransferRateLimited(address indexed sender, uint64 sequence, uint256 amount, uint256 currentCapacity)",
+  "event OutboundTransferCancelled(uint256 sequence, address recipient, uint256 amount)",
+  "event InboundTransferQueued(bytes32 digest)",
+  "event Paused(bool paused)",
+  "event NotPaused(bool notPaused)",
+  "event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)",
+  "event PauserTransferred(address indexed oldPauser, address indexed newPauser)",
+  "event Upgraded(address indexed implementation)",
+  "event PeerUpdated(uint16 indexed chainId_, bytes32 oldPeerContract, uint8 oldPeerDecimals, bytes32 peerContract, uint8 peerDecimals)",
+  "event ThresholdChanged(uint8 oldThreshold, uint8 threshold)",
+  "event TransceiverAdded(address transceiver, uint256 transceiversNum, uint8 threshold)",
+  "event TransceiverRemoved(address transceiver, uint8 threshold)",
+  "event OutboundTransferLimitUpdated(uint256 oldLimit, uint256 newLimit)",
+  "event InboundTransferLimitUpdated(uint16 indexed chainId, uint256 oldLimit, uint256 newLimit)",
+];

--- a/src/resources/ntt-transceiver.abi.js
+++ b/src/resources/ntt-transceiver.abi.js
@@ -1,0 +1,9 @@
+// Minimal Wormhole NTT v2 transceiver ABI for security-sensitive changes.
+export default [
+  "event Paused(bool paused)",
+  "event NotPaused(bool notPaused)",
+  "event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)",
+  "event PauserTransferred(address indexed oldPauser, address indexed newPauser)",
+  "event Upgraded(address indexed implementation)",
+  "event SetWormholePeer(uint16 chainId, bytes32 peerContract)",
+];

--- a/src/utils/ntt.js
+++ b/src/utils/ntt.js
@@ -1,0 +1,112 @@
+import ethers from "ethers";
+import {base58Encode} from "@polkadot/util-crypto";
+import {hexToU8a} from "@polkadot/util";
+import nttManagerAbi from "../resources/ntt-manager.abi.js";
+
+export const WORMHOLE_CHAINS = Object.freeze({
+  1: "Solana",
+  2: "Ethereum",
+  21: "Sui",
+  30: "Base",
+  73: "Hydration",
+});
+
+// Hydration legs from the audited production deployment manifests. These are
+// intentionally static so a cleared minter or compromised registry entry does
+// not make Snakewatch forget the contract it is meant to monitor.
+export const NTT_DEPLOYMENTS = Object.freeze([
+  {assetId: 18, symbol: "DAI", peerChainId: 2, manager: "0xcFd576F88C90844AEBF45378Fd09931281D8b14d", transceiver: "0xe8660CA48f6f4D98BC48DB7Dd07C1a8E555801eA"},
+  {assetId: 19, symbol: "WBTC", peerChainId: 2, manager: "0x6BFca089916c045b0Ca4A09B655aF9F926189993", transceiver: "0x9a8a1ab288f6749Ce5626DEE1B5d59441BdC187F"},
+  {assetId: 20, symbol: "WETH", peerChainId: 2, manager: "0xB5cEf790D52A57fa619eD96eDd64c5328F3DCFb7", transceiver: "0x8acce9CA511d5D7213F8C3f813B8916087cd00ae"},
+  {assetId: 21, symbol: "USDC", peerChainId: 2, manager: "0xEcEab64542A875C4472671D9Ed1E690cdD4e28fC", transceiver: "0x0d7488B39AA64468a709eC3b3d354DeFE539eD97"},
+  {assetId: 23, symbol: "USDT", peerChainId: 2, manager: "0x5E6C488103b47F804824AE15861638af4C436795", transceiver: "0xd2a16B736F32Df7C0DE72838837656FE0f85Ac0F"},
+  {assetId: 40, symbol: "jitoSOL", peerChainId: 1, manager: "0xcE73C15B9ED02413066DE5B904A36F8e8f9B5331", transceiver: "0xF38D9C3bA6999Dc331b32B416083Fd7e02D17B04"},
+  {assetId: 43, symbol: "PRIME", peerChainId: 1, manager: "0xFCaF4aA069C565d25539028970703F01e47D3E0B", transceiver: "0x4e7b1E55D2354d4Dc6ABD876096Dc201de0541D1"},
+  {assetId: 44, symbol: "EURC", peerChainId: 30, manager: "0x8dd1286A29dF5a2785FB638d6fB1598144Cfbc4C", transceiver: "0x2e84fac378D67Dc2e11026fB4919E80263a87375"},
+  {assetId: 1000745, symbol: "sUSDS", peerChainId: 2, manager: "0x1973E7044d9A7C7bB2d6ea1693A296a9e4B7E448", transceiver: "0x68Ecadd7934D4FcFEABAfB209C95D379B96400cb"},
+  {assetId: 1000752, symbol: "SOL", peerChainId: 1, manager: "0x9e200C0f28D92D296b201D96C8269d3CAFFfA9FF", transceiver: "0x2F04AcF249091425d51e67EeA3C3161ccE283202"},
+  {assetId: 1000753, symbol: "SUI", peerChainId: 21, manager: "0x978443f00cAB6b09445140321EC73a221ebFF5F8", transceiver: "0xA224D6f4e0E276b34D91bfE6c3A5fE6838322AF7"},
+]);
+
+const normalize = value => value?.toString().toLowerCase();
+
+const contracts = new Map(NTT_DEPLOYMENTS.flatMap(deployment => [
+  [normalize(deployment.manager), {...deployment, component: "manager"}],
+  [normalize(deployment.transceiver), {...deployment, component: "transceiver"}],
+]));
+const assets = new Map(NTT_DEPLOYMENTS.map(deployment => [String(deployment.assetId), deployment]));
+const managerInterface = new ethers.utils.Interface(nttManagerAbi);
+const selector = signature => ethers.utils.id(signature).slice(0, 10);
+const executionFailures = new Map([
+  [selector("MintLimitReached()"), {
+    code: "mint_limit_reached",
+    description: "the Hydration runtime mint fuse rejected the delivery",
+  }],
+  [selector("CallerNotMinter(address)"), {
+    code: "caller_not_minter",
+    description: "the Hydration runtime rejected the deployed manager as this asset's minter",
+  }],
+]);
+
+export function knownNttContract(address) {
+  return contracts.get(normalize(address));
+}
+
+export function knownNttAsset(assetId) {
+  return assets.get(String(assetId));
+}
+
+export function nttContractFromPayload({event}) {
+  return knownNttContract(event?.data?.log?.address);
+}
+
+export function nttExecutionFailure(event) {
+  const deployment = knownNttContract(event?.data?.to);
+  if (!deployment) return null;
+
+  const extraData = event.data.extraData;
+  const output = (extraData?.toHex ? extraData.toHex() : extraData?.toString())?.toLowerCase();
+  const failure = output ? executionFailures.get(output.slice(0, 10)) : null;
+  return failure ? {deployment, output, ...failure} : null;
+}
+
+export function wormholeChain(chainId) {
+  return WORMHOLE_CHAINS[Number(chainId)] || `Wormhole chain ${chainId}`;
+}
+
+export function formatNttRecipient(recipient, chainId) {
+  const value = recipient.toString();
+  switch (Number(chainId)) {
+    case 1:
+      return base58Encode(hexToU8a(value));
+    case 2:
+    case 30:
+      return ethers.utils.getAddress(`0x${value.slice(-40)}`);
+    case 21:
+    default:
+      return value;
+  }
+}
+
+export function currencySibling(siblings, method, assetId) {
+  return siblings.find(({section, method: siblingMethod, data}) =>
+    section === "currencies"
+    && siblingMethod === method
+    && data?.currencyId?.toString() === String(assetId));
+}
+
+// The ordinary transfer handler would otherwise report the transferFrom into
+// the manager as a whale transfer in addition to the purpose-built NTT feed.
+export function isNttTransfer({siblings}) {
+  return siblings.some(({section, method, data}) => {
+    if (section !== "evm" || method !== "Log") return false;
+    const raw = data?.log;
+    if (!knownNttContract(raw?.address) || knownNttContract(raw.address).component !== "manager") return false;
+    try {
+      const name = managerInterface.parseLog(raw.toHuman()).name;
+      return ["TransferSent", "OutboundTransferRateLimited"].includes(name);
+    } catch {
+      return false;
+    }
+  });
+}

--- a/tests/ntt.test.js
+++ b/tests/ntt.test.js
@@ -1,0 +1,113 @@
+import ethers from "ethers";
+import nttManagerAbi from "../src/resources/ntt-manager.abi.js";
+import {
+  NTT_DEPLOYMENTS,
+  formatNttRecipient,
+  isNttTransfer,
+  knownNttAsset,
+  knownNttContract,
+  nttExecutionFailure,
+  wormholeChain,
+} from "../src/utils/ntt.js";
+
+describe("NTT deployment metadata", () => {
+  it("pins eleven unique manager/transceiver pairs", () => {
+    expect(NTT_DEPLOYMENTS).toHaveLength(11);
+    expect(new Set(NTT_DEPLOYMENTS.map(({assetId}) => assetId)).size).toBe(11);
+    expect(new Set(NTT_DEPLOYMENTS.flatMap(({manager, transceiver}) =>
+      [manager.toLowerCase(), transceiver.toLowerCase()])).size).toBe(22);
+  });
+
+  it("looks contracts and assets up without address-case sensitivity", () => {
+    const deployment = NTT_DEPLOYMENTS[0];
+    expect(knownNttContract(deployment.manager.toUpperCase())).toMatchObject({
+      assetId: deployment.assetId,
+      component: "manager",
+    });
+    expect(knownNttContract(deployment.transceiver)).toMatchObject({
+      assetId: deployment.assetId,
+      component: "transceiver",
+    });
+    expect(knownNttAsset(deployment.assetId)).toBe(deployment);
+  });
+
+  it("formats recipients according to the destination chain", () => {
+    const evmRecipient = `0x${"00".repeat(12)}${"11".repeat(20)}`;
+    const bytes32Recipient = `0x${"22".repeat(32)}`;
+
+    expect(formatNttRecipient(evmRecipient, 2)).toBe(ethers.utils.getAddress(`0x${"11".repeat(20)}`));
+    expect(formatNttRecipient(bytes32Recipient, 1)).toMatch(/^[1-9A-HJ-NP-Za-km-z]+$/);
+    expect(formatNttRecipient(bytes32Recipient, 21)).toBe(bytes32Recipient);
+    expect(wormholeChain(30)).toBe("Base");
+  });
+});
+
+describe("NTT event recognition", () => {
+  const iface = new ethers.utils.Interface(nttManagerAbi);
+  const deployment = NTT_DEPLOYMENTS[0];
+
+  const substrateLog = ({data, topics}, address = deployment.manager) => ({
+    section: "evm",
+    method: "Log",
+    data: {
+      log: {
+        address,
+        toHuman: () => ({address, data, topics}),
+      },
+    },
+  });
+
+  it("recognizes detailed TransferSent logs from a known manager", () => {
+    const fragment = iface.getEvent("TransferSent(bytes32,bytes32,uint256,uint256,uint16,uint64)");
+    const encoded = iface.encodeEventLog(fragment, [
+      `0x${"11".repeat(32)}`,
+      `0x${"22".repeat(32)}`,
+      1000,
+      0,
+      2,
+      7,
+    ]);
+
+    expect(isNttTransfer({siblings: [substrateLog(encoded)]})).toBe(true);
+  });
+
+  it("ignores the same event signature from an unknown contract", () => {
+    const fragment = iface.getEvent("TransferSent(bytes32,bytes32,uint256,uint256,uint16,uint64)");
+    const encoded = iface.encodeEventLog(fragment, [
+      `0x${"11".repeat(32)}`,
+      `0x${"22".repeat(32)}`,
+      1000,
+      0,
+      2,
+      7,
+    ]);
+
+    expect(isNttTransfer({
+      siblings: [substrateLog(encoded, `0x${"ff".repeat(20)}`)],
+    })).toBe(false);
+  });
+
+  it("classifies actionable runtime failures at known NTT contracts", () => {
+    const mintLimit = ethers.utils.id("MintLimitReached()").slice(0, 10);
+    const failure = nttExecutionFailure({
+      data: {
+        to: deployment.transceiver,
+        extraData: {toHex: () => mintLimit},
+      },
+    });
+
+    expect(failure).toMatchObject({
+      code: "mint_limit_reached",
+      deployment: {assetId: deployment.assetId, component: "transceiver"},
+    });
+  });
+
+  it("does not classify arbitrary user reverts as operational NTT failures", () => {
+    expect(nttExecutionFailure({
+      data: {
+        to: deployment.manager,
+        extraData: {toHex: () => ethers.utils.id("TransferAmountHasDust(uint256,uint256)").slice(0, 10)},
+      },
+    })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- add an always-on Discord feed for NTT sends, redemptions, and cancellations across the eleven production Hydration pairs
- alert webhooks on queueing, mint-fuse and minter-binding failures, and manager/transceiver control-plane changes
- pin audited manager/transceiver addresses, expose Prometheus lifecycle counters, and suppress duplicate generic whale-transfer messages
- document the integration and add focused ABI, deployment-metadata, recipient-formatting, event-recognition, and failure-classification tests

## Verification

- 32 focused and offline regression tests pass
- all eleven manager/transceiver pairs were checked against the hydration-ntt deployment manifests
- syntax and diff checks pass

The complete suite reaches 5 of 6 suites. The remaining legacy events suite cannot connect to wss://rpc-01.basilisk-rococo.hydradx.io and times out after repeated 1006 closures; the current Hydration RPC integration suite passes.