### PR TITLE
bil feed: fix deposit attribution + drop redundant uBIL supply/withdraw

### DIFF
--- a/src/handlers/bil-depositor.js
+++ b/src/handlers/bil-depositor.js
@@ -1,0 +1,36 @@
+import ethers from "ethers";
+
+// BIL Aave pool — emits the Supply whose `onBehalfOf` is the real depositor.
+export const BIL_POOL_ADDRESS = '0x69310fda58c819ad82df7d2cb61841c853337a53';
+
+const supplyIface = new ethers.utils.Interface([
+  'event Supply(address indexed reserve, address user, address indexed onBehalfOf, uint256 amount, uint16 indexed referralCode)',
+]);
+
+// Deposits route through BILDepositZap, so the vault's `Deposited` event records
+// the zap as `user` (not the depositor). The real depositor is the BIL pool's
+// `Supply.onBehalfOf` emitted in the same extrinsic — the account that receives
+// the aBIL collateral. Scan the sibling evm.Log events for it; fall back to the
+// vault arg on any miss (e.g. a vault-only deposit with no Aave layer).
+//
+// Pure (ethers-only) so it can be unit-tested without pulling the handler's
+// polkadot/RPC dependency chain into the test runner.
+export function realDepositor(payload, fallback) {
+  for (const ev of payload.siblings ?? []) {
+    if (ev.section?.toString() !== 'evm' || ev.method?.toString() !== 'Log') continue;
+    let log;
+    try {
+      log = ev.data.log.toHuman();
+    } catch {
+      continue;
+    }
+    if (log?.address?.toLowerCase() !== BIL_POOL_ADDRESS) continue;
+    try {
+      const parsed = supplyIface.parseLog(log);
+      if (parsed.name === 'Supply') return parsed.args.onBehalfOf;
+    } catch {
+      // pool log that isn't a Supply — keep scanning
+    }
+  }
+  return fallback;
+}

--- a/src/handlers/bil.js
+++ b/src/handlers/bil.js
@@ -4,6 +4,7 @@ import {swapHandler} from "./xyk.js";
 import {toAccount} from "../utils/evm.js";
 import bilVaultAbi from "../resources/bil-vault.abi.js";
 import {notInRouter} from "./router.js";
+import {realDepositor} from "./bil-depositor.js";
 
 // BIL vault (ERC-4626 / ERC-7540 HOLLAR wrapper) EVM address on Hydration.
 export const VAULT_ADDRESS = '0x6a21891db0940491603f3cca0a9f4dba4c6e810c';
@@ -46,9 +47,10 @@ export default function bilHandler(events) {
     .onFilter('stableswap', 'BuyExecuted', e => notInRouter(e) && isBilSwap(e), bilSwap);
 }
 
-async function deposited({log: {args: {user, hollarAmount, bilMinted}}}) {
+async function deposited(payload) {
+  const {user, hollarAmount, bilMinted} = payload.log.args;
   await Promise.all([HOLLAR, BIL].map(loadCurrency));
-  const account = await toAccount(user);
+  const account = await toAccount(realDepositor(payload, user));
   const message = `${formatAccount(account)} deposited ${fmtHollar(hollarAmount)} into the 🇧🇷 BIL vault for ${await formatAsset(bil(bilMinted))}`;
   broadcast(message);
 }

--- a/tests/bil.test.js
+++ b/tests/bil.test.js
@@ -1,5 +1,48 @@
 import ethers from "ethers";
 import bilVaultAbi from "../src/resources/bil-vault.abi.js";
+import {realDepositor, BIL_POOL_ADDRESS} from "../src/handlers/bil-depositor.js";
+
+describe("BIL deposit attribution", () => {
+  // Deposits route through BILDepositZap, so the vault's Deposited event names
+  // the zap. The real depositor is the pool Supply's onBehalfOf in the same
+  // extrinsic. realDepositor() must recover it from the sibling evm.Log events.
+  const supply = new ethers.utils.Interface([
+    "event Supply(address indexed reserve, address user, address indexed onBehalfOf, uint256 amount, uint16 indexed referralCode)",
+  ]);
+  const ZAP = "0x646fd203bbcf19b35d79f58413bb07450fdbb1db";
+  const RESERVE = "0x0000000000000000000000000000000100000226";
+
+  // Mock a sibling evm.Log event the way processEvents/onLog expose it.
+  const evmLog = (address, {topics, data}) => ({
+    section: "evm",
+    method: "Log",
+    data: {log: {toHuman: () => ({address, topics, data})}},
+  });
+  const supplyLog = (address, onBehalfOf) =>
+    evmLog(address, supply.encodeEventLog(supply.getEvent("Supply"), [RESERVE, ZAP, onBehalfOf, 100, 0]));
+
+  it("uses the pool Supply onBehalfOf as the depositor", () => {
+    const user = "0x" + "ab".repeat(20);
+    const payload = {
+      siblings: [
+        {section: "balances", method: "Transfer"}, // non-evm sibling is skipped
+        supplyLog(BIL_POOL_ADDRESS, user),
+      ],
+    };
+    expect(realDepositor(payload, ZAP).toLowerCase()).toBe(user);
+  });
+
+  it("ignores Supply logs from other pools", () => {
+    const user = "0x" + "cd".repeat(20);
+    const payload = {siblings: [supplyLog("0x" + "11".repeat(20), user)]};
+    expect(realDepositor(payload, ZAP)).toBe(ZAP); // wrong pool → fallback
+  });
+
+  it("falls back to the vault arg when there is no Supply sibling", () => {
+    expect(realDepositor({siblings: []}, ZAP)).toBe(ZAP);
+    expect(realDepositor({}, ZAP)).toBe(ZAP);
+  });
+});
 
 describe("BIL vault ABI", () => {
   const iface = new ethers.utils.Interface(bilVaultAbi);


### PR DESCRIPTION
Two BIL-feed fixes found while testing the live feed:

**1. Deposit attribution** — deposits route through BILDepositZap, so the vault's `Deposited` event records the *zap* (`0x646F…1db`) as `user`; every deposit showed the same `1db`. Now resolved from the BIL pool's `Supply.onBehalfOf` in the same extrinsic (the account that receives the aBIL), with a fallback to the vault arg.

**2. Redundant uBIL supply/withdraw** — the deposit's `pool.supply(uBIL)` also tripped the generic Aave handler, printing a duplicate `supplied 60.07 uBIL` next to the deposit message. The BIL feed already narrates the vault's deposit/redemption lifecycle, so `borrowing.js` now skips BIL-pool supply/withdraw (mirrors the `isBilSwap` carve-out). HOLLAR borrows/repays in the BIL pool are unaffected.

Both resolvers live in a pure ethers-only `src/handlers/bil-depositor.js`, unit-tested (5 new tests, all green).