### PR TITLE
feat: alert when NTT hub custody falls below issuance

### DIFF
--- a/ALERTS.md
+++ b/ALERTS.md
@@ -283,6 +283,37 @@ echo $ALERT_PRICE_DELTA | jq .
 3. Check logs for configuration errors
 4. Ensure webhook URL is accessible
 
+## NTT backing monitor
+
+Continuously checks that every NTT asset's Hydration issuance stays fully backed
+by underlying custodied on the origin (locking) hub. On each cycle it compares
+`Tokens.TotalIssuance(assetId)` against the hub custody balance
+(`token.balanceOf(manager)` on Ethereum/Base, the custody token account on
+Solana, the `State` object's balance on Sui — all normalized to 8 dp) and
+alerts when custody falls below issuance.
+
+- **`🚨 NTT BACKING INSUFFICIENT`** — custody `<` issuance for an asset; message
+  reports the shortfall, the % backed, and the origin chain. Re-alerts every
+  `BACKING_REALERT_HOURS` while unhealthy.
+- **`✅ NTT BACKING RESTORED`** — custody has recovered to `>=` issuance.
+
+Metrics under the `backing` namespace: `backing_custody`, `backing_issuance`,
+`backing_ratio`, `backing_sufficient`, `backing_shortfall`,
+`backing_check_errors_total`. Live snapshot at `GET /backing`.
+
+Config (all optional):
+
+| Env | Default | Purpose |
+|---|---|---|
+| `ETH_RPC` | publicnode | Ethereum RPC for hub custody reads |
+| `BASE_RPC` | publicnode | Base RPC (EURC) |
+| `SOLANA_RPC` | mainnet-beta | Solana RPC (SOL/jitoSOL/PRIME custody) |
+| `SUI_RPC` | publicnode | Sui RPC (SUI State object) |
+| `BACKING_INTERVAL` | `300` | poll cadence (seconds) |
+| `BACKING_THRESHOLD` | `1` | custody/issuance ratio below which it alerts (`>1` = require a buffer) |
+| `BACKING_REALERT_HOURS` | `6` | re-alert cadence while under-backed |
+| `BACKING_DISABLED` | — | set truthy to skip the monitor |
+
 ## Integration Examples
 
 ### Docker Compose

--- a/src/bot.js
+++ b/src/bot.js
@@ -17,6 +17,7 @@ import circuitbreaker from "./handlers/circuitbreaker.js";
 import deployments from "./handlers/deployments.js";
 import bil from "./handlers/bil.js";
 import ntt from "./handlers/ntt.js";
+import backing from "./handlers/backing.js";
 import {initDiscord} from "./discord.js";
 import "./health.js";
 import {rpc, sha, token, channel} from "./config.js";
@@ -65,6 +66,9 @@ async function main() {
   events.addHandler(deployments);
   events.addHandler(bil);
   events.addHandler(ntt);
+
+  // periodic (not block-driven): poll origin-chain hub custody vs Hydration issuance
+  backing();
 
   if (process.env.NODE_ENV === 'test') {
     console.log('testing mode: pushing testing blocks');

--- a/src/config.js
+++ b/src/config.js
@@ -28,3 +28,13 @@ export const slackAlertHF = process.env.ALERT_HF;
 export const slackAlertRate = process.env.ALERT_RATE;
 export const slackAlertPriceDelta = process.env.ALERT_PRICE_DELTA;
 export const alertDeployment = process.env.ALERT_DEPLOYMENT; // truthy ("1"/"true"/"yes"/"on") to notify on every contract deployment
+
+// ── NTT backing monitor ── origin-chain RPCs for reading hub custody balances
+export const ethRpc = process.env.ETH_RPC || 'https://ethereum-rpc.publicnode.com';
+export const baseRpc = process.env.BASE_RPC || 'https://base-rpc.publicnode.com';
+export const solanaRpc = process.env.SOLANA_RPC || 'https://api.mainnet-beta.solana.com';
+export const suiRpc = process.env.SUI_RPC || 'https://sui-rpc.publicnode.com';
+export const backingIntervalSeconds = Number(process.env.BACKING_INTERVAL || 300); // poll cadence
+export const backingThreshold = Number(process.env.BACKING_THRESHOLD || 1); // custody/supply below this ⇒ under-backed
+export const backingReAlertHours = Number(process.env.BACKING_REALERT_HOURS || 6); // re-alert cadence while under-backed
+export const backingDisabled = /^(1|true|yes|on)$/i.test(process.env.BACKING_DISABLED || ''); // set to skip the monitor

--- a/src/handlers/backing.js
+++ b/src/handlers/backing.js
@@ -1,0 +1,184 @@
+import ethers from "ethers";
+import {api} from "../api.js";
+import {broadcast} from "../discord.js";
+import {getAlerts} from "../utils/alerts.js";
+import {metrics} from "../metrics.js";
+import {endpoints} from "../endpoints.js";
+import {NTT_DEPLOYMENTS, wormholeChain} from "../utils/ntt.js";
+import {normalizeTo8dp, assessBacking} from "../utils/backing.js";
+import erc20Abi from "../resources/erc20.abi.js";
+import {
+  ethRpc, baseRpc, solanaRpc, suiRpc,
+  backingIntervalSeconds, backingThreshold, backingReAlertHours, backingDisabled,
+} from "../config.js";
+
+// Each NTT asset's Hydration issuance must be backed by underlying custodied on
+// the origin (locking) hub. Custody is balance-based on every platform, so this
+// monitor periodically compares hub custody against Tokens.TotalIssuance and
+// alerts when custody < issuance (an under-collateralised, therefore unsafe,
+// bridge state). See src/utils/ntt.js for the audited hub-custody addresses.
+
+const backingMetrics = metrics.register("backing", {
+  custody: {type: "gauge", help: "Underlying held by the NTT hub custody (human units)", labels: ["asset", "chain"]},
+  issuance: {type: "gauge", help: "Hydration issuance backed by the NTT hub (human units)", labels: ["asset"]},
+  ratio: {type: "gauge", help: "custody / issuance (>= 1 is fully backed)", labels: ["asset"]},
+  sufficient: {type: "gauge", help: "1 when custody >= issuance, else 0", labels: ["asset"]},
+  shortfall: {type: "gauge", help: "issuance not covered by custody (human units, 0 when healthy)", labels: ["asset"]},
+  check_errors_total: {type: "counter", help: "Backing checks that could not complete", labels: ["asset", "chain"]},
+});
+
+// per-asset alert state so we alert on transition + on a slow re-alert cadence, not every tick
+const state = new Map(); // symbol -> {sufficient, lastAlertAt}
+const lastReport = new Map(); // symbol -> latest computed snapshot (for the /backing endpoint)
+
+const evmProviders = new Map();
+function evmProvider(peerChainId) {
+  const [url, chainId, name] = peerChainId === 30
+    ? [baseRpc, 8453, "base"]
+    : [ethRpc, 1, "ethereum"];
+  if (!evmProviders.has(chainId)) evmProviders.set(chainId, new ethers.providers.StaticJsonRpcProvider(url, {chainId, name}));
+  return evmProviders.get(chainId);
+}
+
+const human8 = v8 => Number(v8) / 1e8;
+
+async function readIssuance(deployment) {
+  const total = await api().query.tokens.totalIssuance(deployment.assetId);
+  return BigInt(total.toString());
+}
+
+async function readCustody(deployment) {
+  const {peerChainId, hub} = deployment;
+  if (peerChainId === 2 || peerChainId === 30) {
+    const c = new ethers.Contract(hub.token, erc20Abi, evmProvider(peerChainId));
+    const bal = await c.balanceOf(hub.custody);
+    return BigInt(bal.toString());
+  }
+  if (peerChainId === 1) return readSolanaCustody(hub.custody);
+  if (peerChainId === 21) return readSuiCustody(hub.custody);
+  throw new Error(`no custody reader for wormhole chain ${peerChainId}`);
+}
+
+async function rpc(url, method, params) {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {"content-type": "application/json"},
+    body: JSON.stringify({jsonrpc: "2.0", id: 1, method, params}),
+  });
+  if (!res.ok) throw new Error(`${method} http ${res.status}`);
+  const json = await res.json();
+  if (json.error) throw new Error(`${method}: ${json.error.message}`);
+  return json.result;
+}
+
+async function readSolanaCustody(account) {
+  const r = await rpc(solanaRpc, "getTokenAccountBalance", [account]);
+  return BigInt(r?.value?.amount ?? "0");
+}
+
+async function readSuiCustody(stateObjectId) {
+  const r = await rpc(suiRpc, "sui_getObject", [stateObjectId, {showContent: true}]);
+  const b = r?.data?.content?.fields?.balance;
+  const value = b && typeof b === "object" ? (b.value ?? b.fields?.value) : b;
+  return BigInt(value ?? "0");
+}
+
+async function checkOne(deployment) {
+  const chain = wormholeChain(deployment.peerChainId);
+  let issuance8, custody8;
+  try {
+    const [issuanceRaw, custodyRaw] = await Promise.all([readIssuance(deployment), readCustody(deployment)]);
+    issuance8 = normalizeTo8dp(issuanceRaw, await hydrationDecimals(deployment.assetId));
+    custody8 = normalizeTo8dp(custodyRaw, deployment.hub.decimals);
+  } catch (err) {
+    backingMetrics.check_errors_total.inc({asset: deployment.symbol, chain});
+    console.error(`backing: ${deployment.symbol} check failed:`, err?.message ?? err);
+    return null;
+  }
+
+  const {ratio, shortfall8, sufficient} = assessBacking(issuance8, custody8, backingThreshold);
+  const snapshot = {
+    symbol: deployment.symbol, chain,
+    issuance: human8(issuance8), custody: human8(custody8),
+    ratio: Number.isFinite(ratio) ? Number(ratio.toFixed(6)) : null,
+    shortfall: human8(shortfall8), sufficient, at: new Date().toISOString(),
+  };
+  lastReport.set(deployment.symbol, snapshot);
+
+  backingMetrics.custody.set({asset: deployment.symbol, chain}, snapshot.custody);
+  backingMetrics.issuance.set({asset: deployment.symbol}, snapshot.issuance);
+  backingMetrics.ratio.set({asset: deployment.symbol}, Number.isFinite(ratio) ? ratio : 1);
+  backingMetrics.sufficient.set({asset: deployment.symbol}, sufficient ? 1 : 0);
+  backingMetrics.shortfall.set({asset: deployment.symbol}, snapshot.shortfall);
+
+  await maybeAlert(deployment, snapshot);
+  return snapshot;
+}
+
+async function maybeAlert(deployment, snap) {
+  const prev = state.get(deployment.symbol);
+  const now = Date.now();
+  const reAlertMs = backingReAlertHours * 3600 * 1000;
+
+  if (!snap.sufficient) {
+    const becameUnhealthy = !prev || prev.sufficient;
+    const dueForRepeat = prev && !prev.sufficient && now - prev.lastAlertAt >= reAlertMs;
+    if (becameUnhealthy || dueForRepeat) {
+      const pct = snap.ratio === null ? "0" : (snap.ratio * 100).toFixed(2);
+      const message = `${deployment.symbol} NTT backing INSUFFICIENT on ${snap.chain}: custody ${fmt(snap.custody)} < issuance ${fmt(snap.issuance)} (${pct}% backed, shortfall ${fmt(snap.shortfall)} ${deployment.symbol})`;
+      broadcast(`🚨 ${message}`);
+      await getAlerts().sendWebhooks(`🚨 **NTT BACKING INSUFFICIENT** - ${message}`);
+      state.set(deployment.symbol, {sufficient: false, lastAlertAt: now});
+      return;
+    }
+    state.set(deployment.symbol, {sufficient: false, lastAlertAt: prev?.lastAlertAt ?? now});
+    return;
+  }
+
+  if (prev && !prev.sufficient) {
+    const message = `${deployment.symbol} NTT backing restored on ${snap.chain}: custody ${fmt(snap.custody)} >= issuance ${fmt(snap.issuance)} (${(snap.ratio * 100).toFixed(2)}% backed)`;
+    broadcast(`✅ ${message}`);
+    await getAlerts().sendWebhooks(`✅ **NTT BACKING RESTORED** - ${message}`);
+  }
+  state.set(deployment.symbol, {sufficient: true, lastAlertAt: prev?.lastAlertAt ?? 0});
+}
+
+const fmt = n => n.toLocaleString("en-US", {maximumFractionDigits: 8});
+
+const decimalsCache = new Map();
+async function hydrationDecimals(assetId) {
+  if (decimalsCache.has(assetId)) return decimalsCache.get(assetId);
+  const asset = await api().query.assetRegistry.assets(assetId);
+  const human = asset.toHuman?.() ?? {};
+  const decimals = Number(human.decimals ?? 0) || 0;
+  decimalsCache.set(assetId, decimals);
+  return decimals;
+}
+
+export async function checkAllBacking() {
+  return Promise.all(NTT_DEPLOYMENTS.map(checkOne));
+}
+
+let timer = null;
+
+export default function backing() {
+  endpoints.registerEndpoint("backing", {
+    "/": {GET: (_, res) => res.json({threshold: backingThreshold, assets: Object.fromEntries(lastReport)})},
+  });
+
+  if (backingDisabled) {
+    console.log("ntt backing monitor disabled (BACKING_DISABLED)");
+    return;
+  }
+
+  console.log(`watching NTT backing (every ${backingIntervalSeconds}s, threshold ${backingThreshold})`);
+  const run = () => checkAllBacking().catch(err => console.error("backing: sweep failed:", err?.message ?? err));
+  run();
+  timer = setInterval(run, backingIntervalSeconds * 1000);
+  if (timer.unref) timer.unref();
+}
+
+export function stopBacking() {
+  if (timer) clearInterval(timer);
+  timer = null;
+}

--- a/src/utils/backing.js
+++ b/src/utils/backing.js
@@ -1,0 +1,18 @@
+// Pure backing math, kept dependency-free so it is trivially unit-testable and
+// importable without pulling in the block/discord/metrics runtime.
+
+/** Floor a raw integer amount to NTT precision (8 dp) so amounts across chains/decimals are comparable. */
+export function normalizeTo8dp(raw, decimals) {
+  const v = BigInt(raw);
+  if (decimals > 8) return v / 10n ** BigInt(decimals - 8);
+  if (decimals < 8) return v * 10n ** BigInt(8 - decimals);
+  return v;
+}
+
+/** Assess backing from 8-dp-normalized custody + issuance. threshold >= 1 requires an over-collateralisation buffer. */
+export function assessBacking(issuance8, custody8, threshold = 1) {
+  const shortfall8 = issuance8 > custody8 ? issuance8 - custody8 : 0n;
+  const ratio = issuance8 === 0n ? Infinity : Number(custody8) / Number(issuance8);
+  const sufficient = issuance8 === 0n ? true : ratio >= threshold;
+  return {ratio, shortfall8, sufficient};
+}

--- a/src/utils/ntt.js
+++ b/src/utils/ntt.js
@@ -14,18 +14,25 @@ export const WORMHOLE_CHAINS = Object.freeze({
 // Hydration legs from the audited production deployment manifests. These are
 // intentionally static so a cleared minter or compromised registry entry does
 // not make Snakewatch forget the contract it is meant to monitor.
+//
+// `hub` is the origin-chain locking leg that must custody enough underlying to
+// back the Hydration issuance. Custody is balance-based on every platform
+// (evm: token.balanceOf(manager); solana: the custody token account; sui: the
+// State object's balance), so the backing monitor just reads that balance.
+// Cross-checked against hydration-ntt/ops/tokens/<sym>/deployment.json and the
+// production @galacticcouncil/xc-cfg NTT config.
 export const NTT_DEPLOYMENTS = Object.freeze([
-  {assetId: 18, symbol: "DAI", peerChainId: 2, manager: "0xcFd576F88C90844AEBF45378Fd09931281D8b14d", transceiver: "0xe8660CA48f6f4D98BC48DB7Dd07C1a8E555801eA"},
-  {assetId: 19, symbol: "WBTC", peerChainId: 2, manager: "0x6BFca089916c045b0Ca4A09B655aF9F926189993", transceiver: "0x9a8a1ab288f6749Ce5626DEE1B5d59441BdC187F"},
-  {assetId: 20, symbol: "WETH", peerChainId: 2, manager: "0xB5cEf790D52A57fa619eD96eDd64c5328F3DCFb7", transceiver: "0x8acce9CA511d5D7213F8C3f813B8916087cd00ae"},
-  {assetId: 21, symbol: "USDC", peerChainId: 2, manager: "0xEcEab64542A875C4472671D9Ed1E690cdD4e28fC", transceiver: "0x0d7488B39AA64468a709eC3b3d354DeFE539eD97"},
-  {assetId: 23, symbol: "USDT", peerChainId: 2, manager: "0x5E6C488103b47F804824AE15861638af4C436795", transceiver: "0xd2a16B736F32Df7C0DE72838837656FE0f85Ac0F"},
-  {assetId: 40, symbol: "jitoSOL", peerChainId: 1, manager: "0xcE73C15B9ED02413066DE5B904A36F8e8f9B5331", transceiver: "0xF38D9C3bA6999Dc331b32B416083Fd7e02D17B04"},
-  {assetId: 43, symbol: "PRIME", peerChainId: 1, manager: "0xFCaF4aA069C565d25539028970703F01e47D3E0B", transceiver: "0x4e7b1E55D2354d4Dc6ABD876096Dc201de0541D1"},
-  {assetId: 44, symbol: "EURC", peerChainId: 30, manager: "0x8dd1286A29dF5a2785FB638d6fB1598144Cfbc4C", transceiver: "0x2e84fac378D67Dc2e11026fB4919E80263a87375"},
-  {assetId: 1000745, symbol: "sUSDS", peerChainId: 2, manager: "0x1973E7044d9A7C7bB2d6ea1693A296a9e4B7E448", transceiver: "0x68Ecadd7934D4FcFEABAfB209C95D379B96400cb"},
-  {assetId: 1000752, symbol: "SOL", peerChainId: 1, manager: "0x9e200C0f28D92D296b201D96C8269d3CAFFfA9FF", transceiver: "0x2F04AcF249091425d51e67EeA3C3161ccE283202"},
-  {assetId: 1000753, symbol: "SUI", peerChainId: 21, manager: "0x978443f00cAB6b09445140321EC73a221ebFF5F8", transceiver: "0xA224D6f4e0E276b34D91bfE6c3A5fE6838322AF7"},
+  {assetId: 18, symbol: "DAI", peerChainId: 2, manager: "0xcFd576F88C90844AEBF45378Fd09931281D8b14d", transceiver: "0xe8660CA48f6f4D98BC48DB7Dd07C1a8E555801eA", hub: {custody: "0x804F123f75cCa0A9c0Cba341F82f4A4DA86a5259", token: "0x6B175474E89094C44Da98b954EedeAC495271d0F", decimals: 18}},
+  {assetId: 19, symbol: "WBTC", peerChainId: 2, manager: "0x6BFca089916c045b0Ca4A09B655aF9F926189993", transceiver: "0x9a8a1ab288f6749Ce5626DEE1B5d59441BdC187F", hub: {custody: "0x081b76AC3cFb65DCe93961d66cea44A74EC8Ef28", token: "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599", decimals: 8}},
+  {assetId: 20, symbol: "WETH", peerChainId: 2, manager: "0xB5cEf790D52A57fa619eD96eDd64c5328F3DCFb7", transceiver: "0x8acce9CA511d5D7213F8C3f813B8916087cd00ae", hub: {custody: "0x283B14B5Dd352e32154Df014EA96834F395E04b6", token: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", decimals: 18}},
+  {assetId: 21, symbol: "USDC", peerChainId: 2, manager: "0xEcEab64542A875C4472671D9Ed1E690cdD4e28fC", transceiver: "0x0d7488B39AA64468a709eC3b3d354DeFE539eD97", hub: {custody: "0x447b2c7485A3d6813F8197E605b10BcCD8dd8398", token: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", decimals: 6}},
+  {assetId: 23, symbol: "USDT", peerChainId: 2, manager: "0x5E6C488103b47F804824AE15861638af4C436795", transceiver: "0xd2a16B736F32Df7C0DE72838837656FE0f85Ac0F", hub: {custody: "0x9fbd9F16cE7Fa17097E91cc36DC1B7b47aDCa9De", token: "0xdAC17F958D2ee523a2206206994597C13D831ec7", decimals: 6}},
+  {assetId: 40, symbol: "jitoSOL", peerChainId: 1, manager: "0xcE73C15B9ED02413066DE5B904A36F8e8f9B5331", transceiver: "0xF38D9C3bA6999Dc331b32B416083Fd7e02D17B04", hub: {custody: "GL9A9wzcn2aPJCaab2NaeFv4SmUadEGS3iY8PtdqFU2Q", decimals: 9}},
+  {assetId: 43, symbol: "PRIME", peerChainId: 1, manager: "0xFCaF4aA069C565d25539028970703F01e47D3E0B", transceiver: "0x4e7b1E55D2354d4Dc6ABD876096Dc201de0541D1", hub: {custody: "7ND1JXFtoH8nn4rvRUvukDwAKgGuJ6uDtFTfTaR9VXiC", decimals: 6}},
+  {assetId: 44, symbol: "EURC", peerChainId: 30, manager: "0x8dd1286A29dF5a2785FB638d6fB1598144Cfbc4C", transceiver: "0x2e84fac378D67Dc2e11026fB4919E80263a87375", hub: {custody: "0xD1dc3517732c98502b5c1ba2389AcA9E9016d89a", token: "0x60a3E35Cc302bFA44Cb288Bc5a4F316Fdb1adb42", decimals: 6}},
+  {assetId: 1000745, symbol: "sUSDS", peerChainId: 2, manager: "0x1973E7044d9A7C7bB2d6ea1693A296a9e4B7E448", transceiver: "0x68Ecadd7934D4FcFEABAfB209C95D379B96400cb", hub: {custody: "0x5085A4863f89eC9553F70187EE73B5aAe0fd14b5", token: "0xa3931d71877C0E7a3148CB7Eb4463524FEc27fbD", decimals: 18}},
+  {assetId: 1000752, symbol: "SOL", peerChainId: 1, manager: "0x9e200C0f28D92D296b201D96C8269d3CAFFfA9FF", transceiver: "0x2F04AcF249091425d51e67EeA3C3161ccE283202", hub: {custody: "4Z2n3D6szuyPkg2uRbm6NwvjpXzKifKQ8HvxhykknyvF", decimals: 9}},
+  {assetId: 1000753, symbol: "SUI", peerChainId: 21, manager: "0x978443f00cAB6b09445140321EC73a221ebFF5F8", transceiver: "0xA224D6f4e0E276b34D91bfE6c3A5fE6838322AF7", hub: {custody: "0xa0bc45e0384140dc125f273eda89cad1434f5dee430726cf6364bdcceba1e9a3", decimals: 9}},
 ]);
 
 const normalize = value => value?.toString().toLowerCase();

--- a/tests/backing.test.js
+++ b/tests/backing.test.js
@@ -1,0 +1,59 @@
+import {normalizeTo8dp, assessBacking} from "../src/utils/backing.js";
+import {NTT_DEPLOYMENTS} from "../src/utils/ntt.js";
+
+describe("backing: normalizeTo8dp", () => {
+  it("scales 18dp down to 8dp (floor)", () => {
+    // 1.23456789987654321 * 1e18 -> 1.23456789 * 1e8
+    expect(normalizeTo8dp(1234567899876543210n, 18)).toBe(123456789n);
+  });
+  it("scales 6dp up to 8dp", () => {
+    expect(normalizeTo8dp(55000000000n, 6)).toBe(5500000000000n); // 55,000 * 1e8
+  });
+  it("is identity at 8dp", () => {
+    expect(normalizeTo8dp(42n, 8)).toBe(42n);
+  });
+  it("accepts string / bigint raw", () => {
+    expect(normalizeTo8dp("100000000", 8)).toBe(100000000n);
+  });
+});
+
+describe("backing: assessBacking", () => {
+  it("is sufficient when custody >= issuance", () => {
+    const r = assessBacking(1000n, 1000n);
+    expect(r.sufficient).toBe(true);
+    expect(r.shortfall8).toBe(0n);
+    expect(r.ratio).toBe(1);
+  });
+  it("flags a shortfall when custody < issuance", () => {
+    const r = assessBacking(1000n, 400n);
+    expect(r.sufficient).toBe(false);
+    expect(r.shortfall8).toBe(600n);
+    expect(r.ratio).toBeCloseTo(0.4);
+  });
+  it("treats zero issuance as trivially backed", () => {
+    const r = assessBacking(0n, 0n);
+    expect(r.sufficient).toBe(true);
+    expect(r.shortfall8).toBe(0n);
+  });
+  it("respects a >1 threshold (require an over-collateralisation buffer)", () => {
+    expect(assessBacking(1000n, 1000n, 1.1).sufficient).toBe(false);
+    expect(assessBacking(1000n, 1100n, 1.1).sufficient).toBe(true);
+  });
+});
+
+describe("backing: NTT hub-custody config integrity", () => {
+  it("every deployment carries a hub custody + decimals", () => {
+    for (const d of NTT_DEPLOYMENTS) {
+      expect(typeof d.hub?.custody).toBe("string");
+      expect(d.hub.custody.length).toBeGreaterThan(0);
+      expect(Number.isInteger(d.hub.decimals)).toBe(true);
+    }
+  });
+  it("EVM hubs (Ethereum/Base) carry an origin token for balanceOf; Solana/Sui do not require one", () => {
+    for (const d of NTT_DEPLOYMENTS) {
+      if (d.peerChainId === 2 || d.peerChainId === 30) {
+        expect(d.hub.token).toMatch(/^0x[0-9a-fA-F]{40}$/);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Adds a periodic monitor that catches an under-collateralised NTT bridge — where Hydration issuance exceeds the underlying custodied on the origin locking hub.

- Every `BACKING_INTERVAL` (default 300s), per NTT asset → compare `Tokens.TotalIssuance(assetId)` vs hub custody, normalized to 8dp.
- Hub custody read per platform → EVM `token.balanceOf(manager)` (Ethereum/Base), Solana custody token account, Sui `State` object balance. All three reader paths validated against live mainnet.
- Alerts → `🚨 NTT BACKING INSUFFICIENT` (custody < issuance; reports shortfall + % backed + chain), re-alerting every `BACKING_REALERT_HOURS`; `✅ NTT BACKING RESTORED` on recovery. Debounced (transition + slow repeat), so no per-tick spam.
- Metrics → `backing_{custody,issuance,ratio,sufficient,shortfall,check_errors_total}`; live snapshot at `GET /backing`.
- Hub-custody addresses added to the existing static, audited `NTT_DEPLOYMENTS` (cross-checked against `hydration-ntt` `deployment.json` + production `@galacticcouncil/xc-cfg`) — deliberately not runtime-fetched, matching the existing philosophy.
- Pure math split into `utils/backing.js`; `tests/backing.test.js` (10 tests) covers normalization, sufficiency/threshold, and config integrity. Full suite green.

Config (all optional, sane public defaults): `ETH_RPC` / `BASE_RPC` / `SOLANA_RPC` / `SUI_RPC`, `BACKING_INTERVAL`, `BACKING_THRESHOLD` (`>1` to require a buffer), `BACKING_REALERT_HOURS`, `BACKING_DISABLED`.

Note: during the ongoing MRL→NTT migration several assets are intentionally partially backed, so the monitor will flag them until custody seeding completes — that's the invariant working as intended.