### PR TITLE
bil feed: drop redundant BIL-pool uBIL supply/withdraw

### DIFF
--- a/src/handlers/bil-depositor.js
+++ b/src/handlers/bil-depositor.js
@@ -7,6 +7,15 @@ const supplyIface = new ethers.utils.Interface([
   'event Supply(address indexed reserve, address user, address indexed onBehalfOf, uint256 amount, uint16 indexed referralCode)',
 ]);
 
+// True when an Aave evm.Log came from the BIL pool. The BIL feed narrates the
+// vault's deposit / redemption lifecycle — the only source of the BIL pool's
+// uBIL supplies and withdraws — so the generic borrowing handler skips those to
+// avoid a duplicate "supplied/withdrew uBIL" line next to the vault message.
+export function isBilPool(payload) {
+  const addr = payload?.event?.data?.log?.address?.toString?.();
+  return addr?.toLowerCase() === BIL_POOL_ADDRESS;
+}
+
 // Deposits route through BILDepositZap, so the vault's `Deposited` event records
 // the zap as `user` (not the depositor). The real depositor is the BIL pool's
 // `Supply.onBehalfOf` emitted in the same extrinsic — the account that receives

--- a/src/handlers/borrowing.js
+++ b/src/handlers/borrowing.js
@@ -9,6 +9,7 @@ import {notInRouter} from "./router.js";
 import {getAlerts} from "../utils/alerts.js";
 import ethers from "ethers";
 import {borrowMarketFlag} from "../markets.js";
+import {isBilPool} from "./bil-depositor.js";
 
 const borrowers = new Borrowers();
 
@@ -18,8 +19,11 @@ const notDusted = ({siblings}) => siblings.find(({section, method}) =>
 export default function borrowingHandler(events) {
   borrowers.init();
   events
-    .onLog('Supply', poolAbi, borrowers.handler(supply), notInRouter)
-    .onLog('Withdraw', poolAbi, borrowers.handler(withdraw), e => notInRouter(e) && notDusted(e))
+    // BIL-pool uBIL supplies/withdraws are vault mechanics already narrated by
+    // the BIL feed's deposit/redemption messages — skip them here to avoid a
+    // duplicate "supplied/withdrew uBIL" line.
+    .onLog('Supply', poolAbi, borrowers.handler(supply), e => notInRouter(e) && !isBilPool(e))
+    .onLog('Withdraw', poolAbi, borrowers.handler(withdraw), e => notInRouter(e) && notDusted(e) && !isBilPool(e))
     .onLog('Borrow', poolAbi, borrowers.handler(borrow))
     .onLog('Repay', poolAbi, borrowers.handler(repay))
     .onLog('LiquidationCall', poolAbi, borrowers.handler(liquidationCall))

--- a/tests/bil.test.js
+++ b/tests/bil.test.js
@@ -1,6 +1,17 @@
 import ethers from "ethers";
 import bilVaultAbi from "../src/resources/bil-vault.abi.js";
-import {realDepositor, BIL_POOL_ADDRESS} from "../src/handlers/bil-depositor.js";
+import {realDepositor, isBilPool, BIL_POOL_ADDRESS} from "../src/handlers/bil-depositor.js";
+
+describe("BIL pool carve-out", () => {
+  const withAddress = address => ({event: {data: {log: {address: {toString: () => address}}}}});
+  it("flags evm.Log from the BIL pool", () => {
+    expect(isBilPool(withAddress(BIL_POOL_ADDRESS.toUpperCase()))).toBe(true);
+  });
+  it("ignores other pools / malformed payloads", () => {
+    expect(isBilPool(withAddress("0x" + "11".repeat(20)))).toBe(false);
+    expect(isBilPool({})).toBeFalsy();
+  });
+});
 
 describe("BIL deposit attribution", () => {
   // Deposits route through BILDepositZap, so the vault's Deposited event names


### PR DESCRIPTION
Follow-up to #53 (which merged before this commit landed).

A BIL deposit's `pool.supply(uBIL)` also tripped the generic Aave handler in `borrowing.js`, printing a duplicate `supplied 60.07 uBIL` next to the vault deposit message. The BIL feed already narrates the vault's deposit/redemption lifecycle, so `borrowing.js` now skips **BIL-pool supply and withdraw** via a new `isBilPool()` predicate (mirrors the `isBilSwap` carve-out). HOLLAR borrows/repays in the BIL pool are unaffected.

`isBilPool` lives in the pure ethers-only `bil-depositor.js`; 2 new unit tests, all green.